### PR TITLE
Add CSV import pipeline for sample results

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/carlos-loya/water-quality-data-management/internal/events"
+	"github.com/carlos-loya/water-quality-data-management/internal/ingestion"
 	"github.com/carlos-loya/water-quality-data-management/internal/storage"
 )
 
@@ -296,6 +297,49 @@ func (h *handler) listAuditLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, entries)
+}
+
+func (h *handler) importSampleResults(w http.ResponseWriter, r *http.Request) {
+	orgID, err := parseUUID(r.PathValue("org_id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid org_id")
+		return
+	}
+
+	// Parse multipart form — 10 MB max
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid multipart form")
+		return
+	}
+
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing file field")
+		return
+	}
+	defer file.Close()
+
+	enteredByStr := r.FormValue("entered_by")
+	enteredBy, err := parseUUID(enteredByStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid or missing entered_by")
+		return
+	}
+
+	importer := ingestion.NewCSVImporter(h.queries)
+	result, err := importer.Import(r.Context(), file, orgID, enteredBy)
+	if err != nil {
+		slog.Error("csv import", "error", err)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Publish audit events for each imported result
+	for _, sr := range result.Results {
+		h.publishResultEvent(r.Context(), events.SubjectSampleResultCreated, "insert", sr, nil)
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // publishResultEvent sends a change event for a sample result to NATS.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,6 +20,7 @@ func NewRouter(queries *storage.Queries, bus *events.Bus) http.Handler {
 	mux.HandleFunc("POST /api/v1/sample-results", h.createSampleResult)
 	mux.HandleFunc("PATCH /api/v1/sample-results/{id}/review", h.reviewSampleResult)
 	mux.HandleFunc("PATCH /api/v1/sample-results/{id}/approve", h.approveSampleResult)
+	mux.HandleFunc("POST /api/v1/organizations/{org_id}/sample-results/import", h.importSampleResults)
 	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/compliance", h.evaluateCompliance)
 	mux.HandleFunc("GET /api/v1/audit-log/{record_id}", h.listAuditLog)
 

--- a/internal/ingestion/csv.go
+++ b/internal/ingestion/csv.go
@@ -1,0 +1,260 @@
+package ingestion
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/carlos-loya/water-quality-data-management/internal/storage"
+)
+
+// CSVImportResult summarizes the outcome of a CSV import.
+type CSVImportResult struct {
+	TotalRows    int            `json:"total_rows"`
+	Imported     int            `json:"imported"`
+	Rejected     int            `json:"rejected"`
+	Results      []storage.SampleResult `json:"results,omitempty"`
+	Errors       []RowError     `json:"errors,omitempty"`
+}
+
+// RowError describes why a specific CSV row was rejected.
+type RowError struct {
+	Row    int    `json:"row"`
+	Field  string `json:"field"`
+	Detail string `json:"detail"`
+}
+
+// Required CSV columns.
+var requiredColumns = []string{
+	"monitoring_location",
+	"parameter_code",
+	"collected_at",
+	"result_value",
+	"unit_code",
+}
+
+// CSVImporter handles parsing and importing CSV data into sample_results.
+type CSVImporter struct {
+	queries *storage.Queries
+}
+
+// NewCSVImporter creates a new importer.
+func NewCSVImporter(queries *storage.Queries) *CSVImporter {
+	return &CSVImporter{queries: queries}
+}
+
+// Import reads a CSV from r and inserts valid rows as sample results.
+// orgID scopes the lookup of parameters, units, and monitoring locations.
+// enteredBy is the user performing the import.
+func (imp *CSVImporter) Import(ctx context.Context, r io.Reader, orgID, enteredBy uuid.UUID) (*CSVImportResult, error) {
+	reader := csv.NewReader(r)
+	reader.TrimLeadingSpace = true
+
+	// Read header
+	header, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+	colIndex := buildColumnIndex(header)
+
+	// Validate required columns exist
+	for _, col := range requiredColumns {
+		if _, ok := colIndex[col]; !ok {
+			return nil, fmt.Errorf("missing required column: %s", col)
+		}
+	}
+
+	// Build lookup maps for validation
+	locations, err := imp.queries.ListAllMonitoringLocations(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("load locations: %w", err)
+	}
+	locByName := make(map[string]storage.MonitoringLocation, len(locations))
+	for _, l := range locations {
+		locByName[strings.ToUpper(l.Name)] = l
+	}
+
+	parameters, err := imp.queries.ListParameters(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("load parameters: %w", err)
+	}
+	paramByCode := make(map[string]storage.Parameter, len(parameters))
+	for _, p := range parameters {
+		paramByCode[strings.ToUpper(p.Code)] = p
+	}
+
+	units, err := imp.queries.ListUnits(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("load units: %w", err)
+	}
+	unitByCode := make(map[string]uuid.UUID, len(units))
+	for _, u := range units {
+		unitByCode[strings.ToUpper(u.Code)] = u.ID
+	}
+
+	// Process rows
+	result := &CSVImportResult{}
+	rowNum := 1 // 1-indexed, header is row 0
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read row %d: %w", rowNum+1, err)
+		}
+		rowNum++
+		result.TotalRows++
+
+		params, rowErrors := imp.parseRow(record, colIndex, rowNum, locByName, paramByCode, unitByCode, enteredBy)
+		if len(rowErrors) > 0 {
+			result.Errors = append(result.Errors, rowErrors...)
+			result.Rejected++
+			continue
+		}
+
+		sr, err := imp.queries.CreateSampleResult(ctx, params)
+		if err != nil {
+			result.Errors = append(result.Errors, RowError{
+				Row:    rowNum,
+				Field:  "",
+				Detail: fmt.Sprintf("database insert: %v", err),
+			})
+			result.Rejected++
+			continue
+		}
+		result.Results = append(result.Results, sr)
+		result.Imported++
+	}
+
+	return result, nil
+}
+
+func (imp *CSVImporter) parseRow(
+	record []string,
+	colIndex map[string]int,
+	rowNum int,
+	locByName map[string]storage.MonitoringLocation,
+	paramByCode map[string]storage.Parameter,
+	unitByCode map[string]uuid.UUID,
+	enteredBy uuid.UUID,
+) (storage.CreateSampleResultParams, []RowError) {
+	var errors []RowError
+	var params storage.CreateSampleResultParams
+
+	params.EnteredBy = enteredBy
+	params.Source = "csv_import"
+
+	// Monitoring location
+	locName := strings.TrimSpace(getCol(record, colIndex, "monitoring_location"))
+	loc, ok := locByName[strings.ToUpper(locName)]
+	if !ok || locName == "" {
+		errors = append(errors, RowError{rowNum, "monitoring_location", fmt.Sprintf("unknown location: %q", locName)})
+	} else {
+		params.MonitoringLocationID = loc.ID
+	}
+
+	// Parameter
+	paramCode := strings.TrimSpace(getCol(record, colIndex, "parameter_code"))
+	param, ok := paramByCode[strings.ToUpper(paramCode)]
+	if !ok || paramCode == "" {
+		errors = append(errors, RowError{rowNum, "parameter_code", fmt.Sprintf("unknown parameter: %q", paramCode)})
+	} else {
+		params.ParameterID = param.ID
+	}
+
+	// Unit
+	unitCode := strings.TrimSpace(getCol(record, colIndex, "unit_code"))
+	unitID, ok := unitByCode[strings.ToUpper(unitCode)]
+	if !ok || unitCode == "" {
+		errors = append(errors, RowError{rowNum, "unit_code", fmt.Sprintf("unknown unit: %q", unitCode)})
+	} else {
+		params.UnitID = unitID
+	}
+
+	// Collected at
+	collectedStr := strings.TrimSpace(getCol(record, colIndex, "collected_at"))
+	collected, err := parseTimestamp(collectedStr)
+	if err != nil {
+		errors = append(errors, RowError{rowNum, "collected_at", fmt.Sprintf("invalid timestamp: %q", collectedStr)})
+	} else {
+		params.CollectedAt = collected
+	}
+
+	// Result value — may include qualifier prefix like "<0.1"
+	valueStr := strings.TrimSpace(getCol(record, colIndex, "result_value"))
+	if valueStr == "" {
+		errors = append(errors, RowError{rowNum, "result_value", "empty"})
+	} else if strings.HasPrefix(valueStr, "<") || strings.EqualFold(valueStr, "ND") {
+		qualifier := "<"
+		if strings.EqualFold(valueStr, "ND") {
+			qualifier = "ND"
+		}
+		params.ResultQualifier = &qualifier
+		// Try to parse detection limit from "<0.1" format
+		if strings.HasPrefix(valueStr, "<") {
+			numStr := strings.TrimPrefix(valueStr, "<")
+			if dl, err := strconv.ParseFloat(numStr, 64); err == nil {
+				params.DetectionLimit = &dl
+			}
+		}
+	} else {
+		val, err := strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			errors = append(errors, RowError{rowNum, "result_value", fmt.Sprintf("not a number: %q", valueStr)})
+		} else {
+			params.ResultValue = &val
+		}
+	}
+
+	// Optional: notes
+	if idx, ok := colIndex["notes"]; ok && idx < len(record) {
+		note := strings.TrimSpace(record[idx])
+		if note != "" {
+			params.Notes = &note
+		}
+	}
+
+	return params, errors
+}
+
+func buildColumnIndex(header []string) map[string]int {
+	idx := make(map[string]int, len(header))
+	for i, col := range header {
+		idx[strings.ToLower(strings.TrimSpace(col))] = i
+	}
+	return idx
+}
+
+func getCol(record []string, colIndex map[string]int, name string) string {
+	i, ok := colIndex[name]
+	if !ok || i >= len(record) {
+		return ""
+	}
+	return record[i]
+}
+
+func parseTimestamp(s string) (time.Time, error) {
+	formats := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05-07:00",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"2006-01-02",
+		"01/02/2006 15:04",
+		"01/02/2006",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized format")
+}

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -131,6 +131,40 @@ func (q *Queries) ListMonitoringLocations(ctx context.Context, facilityID uuid.U
 	return pgx.CollectRows(rows, pgx.RowToStructByName[MonitoringLocation])
 }
 
+// ListAllMonitoringLocations returns all monitoring locations across all facilities for an organization.
+func (q *Queries) ListAllMonitoringLocations(ctx context.Context, orgID uuid.UUID) ([]MonitoringLocation, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT ml.id, ml.facility_id, ml.name, ml.description, ml.location_type, ml.latitude, ml.longitude, ml.active, ml.created_at, ml.updated_at
+		FROM monitoring_locations ml
+		JOIN facilities f ON ml.facility_id = f.id
+		WHERE f.organization_id = $1
+		ORDER BY ml.name`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[MonitoringLocation])
+}
+
+// UnitOfMeasure represents a unit entry.
+type UnitOfMeasure struct {
+	ID   uuid.UUID `json:"id"`
+	Code string    `json:"code"`
+	Name string    `json:"name"`
+}
+
+// ListUnits returns all units of measure for an organization.
+func (q *Queries) ListUnits(ctx context.Context, orgID uuid.UUID) ([]UnitOfMeasure, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT id, code, name
+		FROM units_of_measure
+		WHERE organization_id = $1
+		ORDER BY code`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[UnitOfMeasure])
+}
+
 // ListParameters returns all parameters for an organization.
 func (q *Queries) ListParameters(ctx context.Context, orgID uuid.UUID) ([]Parameter, error) {
 	rows, err := q.pool.Query(ctx, `

--- a/testdata/sample_import.csv
+++ b/testdata/sample_import.csv
@@ -1,0 +1,11 @@
+monitoring_location,parameter_code,collected_at,result_value,unit_code,notes
+CW-EFF,PH,2026-03-17 06:00,7.1,SU,morning reading
+CW-EFF,TURB,2026-03-17 06:00,0.19,NTU,
+CW-EFF,CL2FREE,2026-03-17 06:00,0.85,mg/L,
+WW-EFF,BOD5,2026-03-17 07:00,23.4,mg/L,
+WW-EFF,TSS,2026-03-17 07:00,17.2,mg/L,
+WW-EFF,NH3,2026-03-17 07:00,<0.1,mg/L,below detection
+CW-EFF,PH,2026-03-17 14:00,7.3,SU,afternoon reading
+INVALID-LOC,PH,2026-03-17 06:00,7.0,SU,should fail - bad location
+CW-EFF,BADPARAM,2026-03-17 06:00,1.0,mg/L,should fail - bad parameter
+CW-EFF,PH,not-a-date,7.0,SU,should fail - bad date


### PR DESCRIPTION
## Summary
- **CSV import endpoint** `POST /api/v1/organizations/{org_id}/sample-results/import` accepts multipart file upload
- Validates each row against the org's monitoring locations, parameters, and units
- Handles non-detect values (`<0.1` → qualifier + detection limit)
- Supports multiple timestamp formats (RFC3339, `YYYY-MM-DD HH:MM`, `MM/DD/YYYY`, etc.)
- Per-row error reporting: rejected rows include row number, field name, and error detail
- All imported results get audit trail entries via NATS

## Example response
```json
{
  "total_rows": 10,
  "imported": 7,
  "rejected": 3,
  "errors": [
    {"row": 9, "field": "monitoring_location", "detail": "unknown location: \"INVALID-LOC\""},
    {"row": 10, "field": "parameter_code", "detail": "unknown parameter: \"BADPARAM\""},
    {"row": 11, "field": "collected_at", "detail": "invalid timestamp: \"not-a-date\""}
  ]
}
```

## Test plan
- [x] 7 valid rows import as draft sample results
- [x] 3 invalid rows rejected with specific error details
- [x] Non-detect `<0.1` parsed as qualifier with detection limit
- [x] Notes column carried through to imported records
- [x] Audit log has 7 insert entries after import
- [x] Missing required column in CSV header returns error before processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)