### PR TITLE
Add time-series trending charts with permit limit lines

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -299,6 +299,29 @@ func (h *handler) listAuditLog(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, entries)
 }
 
+func (h *handler) getTrending(w http.ResponseWriter, r *http.Request) {
+	facilityID, err := parseUUID(r.PathValue("facility_id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid facility_id")
+		return
+	}
+
+	days := 30
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 365 {
+			days = n
+		}
+	}
+
+	series, err := h.queries.GetTrendingData(r.Context(), facilityID, days)
+	if err != nil {
+		slog.Error("get trending", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, series)
+}
+
 func (h *handler) importSampleResults(w http.ResponseWriter, r *http.Request) {
 	orgID, err := parseUUID(r.PathValue("org_id"))
 	if err != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -21,6 +21,7 @@ func NewRouter(queries *storage.Queries, bus *events.Bus) http.Handler {
 	mux.HandleFunc("PATCH /api/v1/sample-results/{id}/review", h.reviewSampleResult)
 	mux.HandleFunc("PATCH /api/v1/sample-results/{id}/approve", h.approveSampleResult)
 	mux.HandleFunc("POST /api/v1/organizations/{org_id}/sample-results/import", h.importSampleResults)
+	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/trending", h.getTrending)
 	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/compliance", h.evaluateCompliance)
 	mux.HandleFunc("GET /api/v1/audit-log/{record_id}", h.listAuditLog)
 

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -405,6 +405,115 @@ func (q *Queries) ListAuditLog(ctx context.Context, recordID uuid.UUID) ([]Audit
 	return pgx.CollectRows(rows, pgx.RowToStructByName[AuditEntry])
 }
 
+// TrendingPoint represents a single data point for time-series charting.
+type TrendingPoint struct {
+	CollectedAt   time.Time `json:"collected_at"`
+	ResultValue   *float64  `json:"result_value"`
+	Qualifier     *string   `json:"result_qualifier,omitempty"`
+	LocationName  string    `json:"location_name"`
+	ParameterCode string   `json:"parameter_code"`
+	ParameterName string   `json:"parameter_name"`
+	UnitCode      string   `json:"unit_code"`
+}
+
+// TrendingLimit represents a permit limit line for a chart.
+type TrendingLimit struct {
+	LimitType  string  `json:"limit_type"`
+	LimitValue float64 `json:"limit_value"`
+}
+
+// TrendingSeries groups data points and limits for one parameter at one location.
+type TrendingSeries struct {
+	ParameterCode string          `json:"parameter_code"`
+	ParameterName string          `json:"parameter_name"`
+	LocationName  string          `json:"location_name"`
+	UnitCode      string          `json:"unit_code"`
+	Points        []TrendingPoint `json:"points"`
+	Limits        []TrendingLimit `json:"limits"`
+}
+
+// GetTrendingData returns time-series data for a facility, grouped by parameter+location.
+func (q *Queries) GetTrendingData(ctx context.Context, facilityID uuid.UUID, days int) ([]TrendingSeries, error) {
+	if days <= 0 {
+		days = 30
+	}
+
+	rows, err := q.pool.Query(ctx, `
+		SELECT sr.collected_at, sr.result_value, sr.result_qualifier AS qualifier,
+		       ml.name AS location_name, p.code AS parameter_code, p.name AS parameter_name,
+		       u.code AS unit_code
+		FROM sample_results sr
+		JOIN monitoring_locations ml ON sr.monitoring_location_id = ml.id
+		JOIN facilities f ON ml.facility_id = f.id
+		JOIN parameters p ON sr.parameter_id = p.id
+		JOIN units_of_measure u ON sr.unit_id = u.id
+		WHERE f.id = $1 AND sr.collected_at >= now() - make_interval(days => $2)
+		ORDER BY p.code, ml.name, sr.collected_at`, facilityID, days)
+	if err != nil {
+		return nil, err
+	}
+	points, err := pgx.CollectRows(rows, pgx.RowToStructByName[TrendingPoint])
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current limits for this facility
+	limitRows, err := q.pool.Query(ctx, `
+		SELECT DISTINCT p.code AS parameter_code, ml.name AS location_name,
+		       pl.limit_type, pl.limit_value
+		FROM permit_limits pl
+		JOIN monitoring_locations ml ON pl.monitoring_location_id = ml.id
+		JOIN parameters p ON pl.parameter_id = p.id
+		WHERE ml.facility_id = $1
+		  AND pl.effective_start <= CURRENT_DATE
+		  AND (pl.effective_end IS NULL OR pl.effective_end >= CURRENT_DATE)
+		ORDER BY p.code, ml.name, pl.limit_type`, facilityID)
+	if err != nil {
+		return nil, err
+	}
+
+	type limitKey struct{ param, loc string }
+	limitMap := make(map[limitKey][]TrendingLimit)
+	for limitRows.Next() {
+		var paramCode, locName, limitType string
+		var limitValue float64
+		if err := limitRows.Scan(&paramCode, &locName, &limitType, &limitValue); err != nil {
+			return nil, err
+		}
+		k := limitKey{paramCode, locName}
+		limitMap[k] = append(limitMap[k], TrendingLimit{limitType, limitValue})
+	}
+	limitRows.Close()
+
+	// Group points into series by parameter+location
+	type seriesKey struct{ param, loc string }
+	seriesMap := make(map[seriesKey]*TrendingSeries)
+	var seriesOrder []seriesKey
+
+	for _, pt := range points {
+		k := seriesKey{pt.ParameterCode, pt.LocationName}
+		s, ok := seriesMap[k]
+		if !ok {
+			s = &TrendingSeries{
+				ParameterCode: pt.ParameterCode,
+				ParameterName: pt.ParameterName,
+				LocationName:  pt.LocationName,
+				UnitCode:      pt.UnitCode,
+				Limits:        limitMap[limitKey{pt.ParameterCode, pt.LocationName}],
+			}
+			seriesMap[k] = s
+			seriesOrder = append(seriesOrder, k)
+		}
+		s.Points = append(s.Points, pt)
+	}
+
+	result := make([]TrendingSeries, 0, len(seriesOrder))
+	for _, k := range seriesOrder {
+		result = append(result, *seriesMap[k])
+	}
+	return result, nil
+}
+
 // GetOrganizationIDForResult resolves the organization_id for a sample result
 // by traversing the facility hierarchy.
 func (q *Queries) GetOrganizationIDForResult(ctx context.Context, resultID uuid.UUID) (uuid.UUID, error) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,11 +2,18 @@ import { useState } from "react";
 import { FacilitySelector } from "./components/FacilitySelector";
 import { SampleResultsTable } from "./components/SampleResultsTable";
 import { ComplianceView } from "./components/ComplianceView";
+import { TrendingCharts } from "./components/TrendingCharts";
 
 // Seed data org ID. In a real app this comes from auth.
 const ORG_ID = "019558a0-0000-7000-a000-000000000001";
 
-type Tab = "results" | "compliance";
+type Tab = "results" | "trending" | "compliance";
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: "results", label: "Sample Results" },
+  { key: "trending", label: "Trending" },
+  { key: "compliance", label: "Compliance" },
+];
 
 function App() {
   const [facilityId, setFacilityId] = useState<string | null>(null);
@@ -40,30 +47,26 @@ function App() {
         {facilityId && (
           <>
             <div className="mb-4 flex gap-1 border-b border-gray-200">
-              <button
-                onClick={() => setTab("results")}
-                className={`px-4 py-2 text-sm font-medium ${
-                  tab === "results"
-                    ? "border-b-2 border-blue-500 text-blue-600"
-                    : "text-gray-500 hover:text-gray-700"
-                }`}
-              >
-                Sample Results
-              </button>
-              <button
-                onClick={() => setTab("compliance")}
-                className={`px-4 py-2 text-sm font-medium ${
-                  tab === "compliance"
-                    ? "border-b-2 border-blue-500 text-blue-600"
-                    : "text-gray-500 hover:text-gray-700"
-                }`}
-              >
-                Compliance
-              </button>
+              {TABS.map((t) => (
+                <button
+                  key={t.key}
+                  onClick={() => setTab(t.key)}
+                  className={`px-4 py-2 text-sm font-medium ${
+                    tab === t.key
+                      ? "border-b-2 border-blue-500 text-blue-600"
+                      : "text-gray-500 hover:text-gray-700"
+                  }`}
+                >
+                  {t.label}
+                </button>
+              ))}
             </div>
 
             {tab === "results" && (
               <SampleResultsTable facilityId={facilityId} orgId={ORG_ID} />
+            )}
+            {tab === "trending" && (
+              <TrendingCharts facilityId={facilityId} />
             )}
             {tab === "compliance" && (
               <ComplianceView facilityId={facilityId} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   Parameter,
   SampleResult,
   ComplianceResult,
+  TrendingSeries,
   AuditEntry,
 } from "./types";
 
@@ -53,6 +54,12 @@ export const api = {
 
   evaluateCompliance(facilityId: string) {
     return get<ComplianceResult[]>(`/facilities/${facilityId}/compliance`);
+  },
+
+  getTrending(facilityId: string, days = 30) {
+    return get<TrendingSeries[]>(
+      `/facilities/${facilityId}/trending?days=${days}`
+    );
   },
 
   getAuditLog(recordId: string) {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -75,6 +75,30 @@ export interface ComplianceResult {
   compliance: string;
 }
 
+export interface TrendingPoint {
+  collected_at: string;
+  result_value: number | null;
+  result_qualifier?: string;
+  location_name: string;
+  parameter_code: string;
+  parameter_name: string;
+  unit_code: string;
+}
+
+export interface TrendingLimit {
+  limit_type: string;
+  limit_value: number;
+}
+
+export interface TrendingSeries {
+  parameter_code: string;
+  parameter_name: string;
+  location_name: string;
+  unit_code: string;
+  points: TrendingPoint[];
+  limits: TrendingLimit[];
+}
+
 export interface AuditEntry {
   id: string;
   organization_id: string;

--- a/web/src/components/TrendingCharts.tsx
+++ b/web/src/components/TrendingCharts.tsx
@@ -1,0 +1,173 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+} from "recharts";
+import { api } from "../api/client";
+import type { TrendingSeries } from "../api/types";
+
+interface Props {
+  facilityId: string;
+}
+
+const LIMIT_COLORS: Record<string, string> = {
+  daily_max: "#ef4444",
+  daily_min: "#3b82f6",
+  monthly_avg: "#f97316",
+  weekly_avg: "#a855f7",
+  instantaneous_max: "#dc2626",
+};
+
+function formatLimitLabel(type: string): string {
+  return type
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function SeriesChart({ series }: { series: TrendingSeries }) {
+  const data = series.points
+    .filter((p) => p.result_value !== null)
+    .map((p) => ({
+      date: new Date(p.collected_at).toLocaleDateString(),
+      timestamp: new Date(p.collected_at).getTime(),
+      value: p.result_value,
+    }));
+
+  if (data.length === 0) {
+    return (
+      <div className="py-6 text-center text-sm text-gray-400">
+        No numeric data points
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="mb-3 flex items-baseline justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">
+            {series.parameter_name}
+          </h3>
+          <p className="text-xs text-gray-500">
+            {series.location_name} &middot; {series.unit_code}
+          </p>
+        </div>
+        {series.limits.length > 0 && (
+          <div className="flex gap-3">
+            {series.limits.map((l) => (
+              <span
+                key={l.limit_type}
+                className="flex items-center gap-1 text-xs text-gray-500"
+              >
+                <span
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{
+                    backgroundColor: LIMIT_COLORS[l.limit_type] ?? "#9ca3af",
+                  }}
+                />
+                {formatLimitLabel(l.limit_type)}: {l.limit_value}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 11 }}
+            stroke="#9ca3af"
+          />
+          <YAxis
+            tick={{ fontSize: 11 }}
+            stroke="#9ca3af"
+            width={50}
+          />
+          <Tooltip
+            contentStyle={{
+              fontSize: 12,
+              borderRadius: 8,
+              border: "1px solid #e5e7eb",
+            }}
+            formatter={(value: number) => [
+              `${value} ${series.unit_code}`,
+              series.parameter_name,
+            ]}
+          />
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={{ r: 3, fill: "#3b82f6" }}
+            activeDot={{ r: 5 }}
+          />
+          {series.limits.map((l) => (
+            <ReferenceLine
+              key={l.limit_type}
+              y={l.limit_value}
+              stroke={LIMIT_COLORS[l.limit_type] ?? "#9ca3af"}
+              strokeDasharray="6 3"
+              strokeWidth={1.5}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export function TrendingCharts({ facilityId }: Props) {
+  const [days, setDays] = useState(30);
+
+  const { data: seriesList, isLoading } = useQuery({
+    queryKey: ["trending", facilityId, days],
+    queryFn: () => api.getTrending(facilityId, days),
+  });
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Parameter Trends
+        </h2>
+        <select
+          value={days}
+          onChange={(e) => setDays(Number(e.target.value))}
+          className="rounded border border-gray-300 px-3 py-1.5 text-sm"
+        >
+          <option value={7}>Last 7 days</option>
+          <option value={30}>Last 30 days</option>
+          <option value={90}>Last 90 days</option>
+          <option value={365}>Last year</option>
+        </select>
+      </div>
+
+      {isLoading ? (
+        <div className="py-8 text-center text-sm text-gray-500">Loading...</div>
+      ) : seriesList?.length === 0 ? (
+        <div className="py-8 text-center text-sm text-gray-400">
+          No trending data for this period
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {seriesList?.map((s) => (
+            <SeriesChart
+              key={`${s.parameter_code}-${s.location_name}`}
+              series={s}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Trending API** `GET /api/v1/facilities/{facility_id}/trending?days=30` returns time-series data grouped by parameter+location, with current effective permit limits
- **Recharts line charts** with one chart per parameter/location, showing values over time with dashed permit limit reference lines
- **Period selector** (7d, 30d, 90d, 1y) controls the lookback window
- **Limit legend** color-coded by type (red=daily max, blue=daily min, orange=monthly avg)
- New **Trending tab** on the facility dashboard between Sample Results and Compliance

## Validated end-to-end
- WTP: 4 series (pH with 7 points + min/max limits, Turbidity with max limit, Free Chlorine with min limit, Ammonia)
- WWTP: 4 series (BOD5, TSS, NH3, E. coli each with their permit limits)
- Vite proxy confirmed forwarding trending API requests to Go server

## Test plan
- [x] Trending API returns correct series for WTP (4 series, limits attached)
- [x] Trending API returns correct series for WWTP (4 series, limits attached)
- [x] Frontend compiles (TypeScript clean, Vite build succeeds)
- [x] Vite proxy forwards /api/v1/facilities/.../trending to Go server
- [x] Period selector parameter passed through to API
- [x] Docker + Go server + seed data + frontend all running together

🤖 Generated with [Claude Code](https://claude.com/claude-code)