### PR TITLE
Add instrument calibration tracking with overdue alerts

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -355,6 +355,38 @@ func (h *handler) listAuditLog(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, entries)
 }
 
+func (h *handler) listInstrumentStatuses(w http.ResponseWriter, r *http.Request) {
+	facilityID, err := parseUUID(r.PathValue("facility_id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid facility_id")
+		return
+	}
+
+	statuses, err := h.queries.ListInstrumentStatuses(r.Context(), facilityID)
+	if err != nil {
+		slog.Error("list instrument statuses", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, statuses)
+}
+
+func (h *handler) listCalibrationRecords(w http.ResponseWriter, r *http.Request) {
+	instrumentID, err := parseUUID(r.PathValue("instrument_id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid instrument_id")
+		return
+	}
+
+	records, err := h.queries.ListCalibrationRecords(r.Context(), instrumentID)
+	if err != nil {
+		slog.Error("list calibration records", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, records)
+}
+
 func (h *handler) getTrending(w http.ResponseWriter, r *http.Request) {
 	facilityID, err := parseUUID(r.PathValue("facility_id"))
 	if err != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -22,6 +22,8 @@ func NewRouter(queries *storage.Queries, bus *events.Bus) http.Handler {
 	mux.HandleFunc("PATCH /api/v1/sample-results/{id}/approve", h.approveSampleResult)
 	mux.HandleFunc("POST /api/v1/organizations/{org_id}/sample-results/import", h.importSampleResults)
 	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/trending", h.getTrending)
+	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/instruments", h.listInstrumentStatuses)
+	mux.HandleFunc("GET /api/v1/instruments/{instrument_id}/calibrations", h.listCalibrationRecords)
 	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/compliance", h.evaluateCompliance)
 	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/reports/compliance.xlsx", h.complianceExcel)
 	mux.HandleFunc("GET /api/v1/facilities/{facility_id}/reports/compliance.pdf", h.compliancePDF)

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -514,6 +514,125 @@ func (q *Queries) GetTrendingData(ctx context.Context, facilityID uuid.UUID, day
 	return result, nil
 }
 
+// Instrument represents a lab or field instrument.
+type Instrument struct {
+	ID                  uuid.UUID `json:"id"`
+	FacilityID          uuid.UUID `json:"facility_id"`
+	Name                string    `json:"name"`
+	SerialNumber        *string   `json:"serial_number,omitempty"`
+	InstrumentType      string    `json:"instrument_type"`
+	Manufacturer        *string   `json:"manufacturer,omitempty"`
+	Model               *string   `json:"model,omitempty"`
+	LocationDescription *string   `json:"location_description,omitempty"`
+	Active              bool      `json:"active"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+// CalibrationRecord represents a verification or calibration event.
+type CalibrationRecord struct {
+	ID               uuid.UUID  `json:"id"`
+	InstrumentID     uuid.UUID  `json:"instrument_id"`
+	CalibrationType  string     `json:"calibration_type"`
+	PerformedAt      time.Time  `json:"performed_at"`
+	PerformedBy      uuid.UUID  `json:"performed_by"`
+	DueAt            *time.Time `json:"due_at,omitempty"`
+	Status           string     `json:"status"`
+	PreValue         *float64   `json:"pre_value,omitempty"`
+	PostValue        *float64   `json:"post_value,omitempty"`
+	MethodReference  *string    `json:"method_reference,omitempty"`
+	CorrectiveAction *string    `json:"corrective_action,omitempty"`
+	Notes            *string    `json:"notes,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+}
+
+// InstrumentStatus combines an instrument with its latest calibration info.
+type InstrumentStatus struct {
+	ID                  uuid.UUID  `json:"id"`
+	Name                string     `json:"name"`
+	SerialNumber        *string    `json:"serial_number,omitempty"`
+	InstrumentType      string     `json:"instrument_type"`
+	Manufacturer        *string    `json:"manufacturer,omitempty"`
+	Model               *string    `json:"model,omitempty"`
+	Active              bool       `json:"active"`
+	LastCalibrationType *string    `json:"last_calibration_type,omitempty"`
+	LastPerformedAt     *time.Time `json:"last_performed_at,omitempty"`
+	LastStatus          *string    `json:"last_status,omitempty"`
+	DueAt               *time.Time `json:"due_at,omitempty"`
+	CalibrationStatus   string     `json:"calibration_status"` // "current", "due_soon", "overdue", "no_schedule"
+}
+
+// ListInstruments returns all instruments for a facility.
+func (q *Queries) ListInstruments(ctx context.Context, facilityID uuid.UUID) ([]Instrument, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT id, facility_id, name, serial_number, instrument_type,
+		       manufacturer, model, location_description, active, created_at, updated_at
+		FROM instruments
+		WHERE facility_id = $1
+		ORDER BY name`, facilityID)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[Instrument])
+}
+
+// ListCalibrationRecords returns calibration history for an instrument.
+func (q *Queries) ListCalibrationRecords(ctx context.Context, instrumentID uuid.UUID) ([]CalibrationRecord, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT id, instrument_id, calibration_type, performed_at, performed_by,
+		       due_at, status, pre_value, post_value, method_reference,
+		       corrective_action, notes, created_at, updated_at
+		FROM calibration_records
+		WHERE instrument_id = $1
+		ORDER BY performed_at DESC`, instrumentID)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[CalibrationRecord])
+}
+
+// ListInstrumentStatuses returns instruments with their current calibration status.
+// Flags instruments as overdue (past due_at), due_soon (within 2 days), current, or no_schedule.
+func (q *Queries) ListInstrumentStatuses(ctx context.Context, facilityID uuid.UUID) ([]InstrumentStatus, error) {
+	rows, err := q.pool.Query(ctx, `
+		WITH latest_cal AS (
+			SELECT DISTINCT ON (instrument_id)
+				instrument_id,
+				calibration_type AS last_calibration_type,
+				performed_at AS last_performed_at,
+				status AS last_status,
+				due_at
+			FROM calibration_records
+			ORDER BY instrument_id, performed_at DESC
+		)
+		SELECT
+			i.id, i.name, i.serial_number, i.instrument_type,
+			i.manufacturer, i.model, i.active,
+			lc.last_calibration_type, lc.last_performed_at, lc.last_status, lc.due_at,
+			CASE
+				WHEN lc.due_at IS NULL THEN 'no_schedule'
+				WHEN lc.due_at < now() THEN 'overdue'
+				WHEN lc.due_at < now() + interval '2 days' THEN 'due_soon'
+				ELSE 'current'
+			END AS calibration_status
+		FROM instruments i
+		LEFT JOIN latest_cal lc ON lc.instrument_id = i.id
+		WHERE i.facility_id = $1
+		ORDER BY
+			CASE
+				WHEN lc.due_at IS NULL THEN 3
+				WHEN lc.due_at < now() THEN 0
+				WHEN lc.due_at < now() + interval '2 days' THEN 1
+				ELSE 2
+			END,
+			i.name`, facilityID)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[InstrumentStatus])
+}
+
 // GetOrganizationIDForResult resolves the organization_id for a sample result
 // by traversing the facility hierarchy.
 func (q *Queries) GetOrganizationIDForResult(ctx context.Context, resultID uuid.UUID) (uuid.UUID, error) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,16 +3,18 @@ import { FacilitySelector } from "./components/FacilitySelector";
 import { SampleResultsTable } from "./components/SampleResultsTable";
 import { ComplianceView } from "./components/ComplianceView";
 import { TrendingCharts } from "./components/TrendingCharts";
+import { InstrumentsView } from "./components/InstrumentsView";
 
 // Seed data org ID. In a real app this comes from auth.
 const ORG_ID = "019558a0-0000-7000-a000-000000000001";
 
-type Tab = "results" | "trending" | "compliance";
+type Tab = "results" | "trending" | "compliance" | "instruments";
 
 const TABS: { key: Tab; label: string }[] = [
   { key: "results", label: "Sample Results" },
   { key: "trending", label: "Trending" },
   { key: "compliance", label: "Compliance" },
+  { key: "instruments", label: "Instruments" },
 ];
 
 function App() {
@@ -70,6 +72,9 @@ function App() {
             )}
             {tab === "compliance" && (
               <ComplianceView facilityId={facilityId} />
+            )}
+            {tab === "instruments" && (
+              <InstrumentsView facilityId={facilityId} />
             )}
           </>
         )}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5,6 +5,8 @@ import type {
   SampleResult,
   ComplianceResult,
   TrendingSeries,
+  InstrumentStatus,
+  CalibrationRecord,
   AuditEntry,
 } from "./types";
 
@@ -59,6 +61,16 @@ export const api = {
   getTrending(facilityId: string, days = 30) {
     return get<TrendingSeries[]>(
       `/facilities/${facilityId}/trending?days=${days}`
+    );
+  },
+
+  listInstrumentStatuses(facilityId: string) {
+    return get<InstrumentStatus[]>(`/facilities/${facilityId}/instruments`);
+  },
+
+  listCalibrationRecords(instrumentId: string) {
+    return get<CalibrationRecord[]>(
+      `/instruments/${instrumentId}/calibrations`
     );
   },
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -99,6 +99,38 @@ export interface TrendingSeries {
   limits: TrendingLimit[];
 }
 
+export interface InstrumentStatus {
+  id: string;
+  name: string;
+  serial_number?: string;
+  instrument_type: string;
+  manufacturer?: string;
+  model?: string;
+  active: boolean;
+  last_calibration_type?: string;
+  last_performed_at?: string;
+  last_status?: string;
+  due_at?: string;
+  calibration_status: "current" | "due_soon" | "overdue" | "no_schedule";
+}
+
+export interface CalibrationRecord {
+  id: string;
+  instrument_id: string;
+  calibration_type: string;
+  performed_at: string;
+  performed_by: string;
+  due_at?: string;
+  status: string;
+  pre_value?: number;
+  post_value?: number;
+  method_reference?: string;
+  corrective_action?: string;
+  notes?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface AuditEntry {
   id: string;
   organization_id: string;

--- a/web/src/components/InstrumentsView.tsx
+++ b/web/src/components/InstrumentsView.tsx
@@ -1,0 +1,235 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import type { InstrumentStatus } from "../api/types";
+
+const STATUS_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  overdue: { bg: "bg-red-100", text: "text-red-800", label: "Overdue" },
+  due_soon: { bg: "bg-yellow-100", text: "text-yellow-800", label: "Due Soon" },
+  current: { bg: "bg-green-100", text: "text-green-800", label: "Current" },
+  no_schedule: { bg: "bg-gray-100", text: "text-gray-600", label: "No Schedule" },
+};
+
+function CalStatusBadge({ status }: { status: string }) {
+  const s = STATUS_STYLES[status] ?? STATUS_STYLES.no_schedule;
+  return (
+    <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${s.bg} ${s.text}`}>
+      {s.label}
+    </span>
+  );
+}
+
+function CalibrationHistory({ instrumentId, instrumentName }: { instrumentId: string; instrumentName: string }) {
+  const { data: records, isLoading } = useQuery({
+    queryKey: ["calibrations", instrumentId],
+    queryFn: () => api.listCalibrationRecords(instrumentId),
+  });
+
+  return (
+    <div className="mt-3 rounded border border-gray-200 bg-gray-50 p-4">
+      <h4 className="mb-3 text-sm font-medium text-gray-700">
+        Calibration History — {instrumentName}
+      </h4>
+      {isLoading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : records?.length === 0 ? (
+        <div className="text-sm text-gray-400">No calibration records</div>
+      ) : (
+        <div className="space-y-2">
+          {records?.map((r) => (
+            <div key={r.id} className="rounded border border-gray-200 bg-white p-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-gray-800">
+                    {r.calibration_type.charAt(0).toUpperCase() + r.calibration_type.slice(1)}
+                  </span>
+                  <span
+                    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                      r.status === "pass"
+                        ? "bg-green-100 text-green-800"
+                        : "bg-red-100 text-red-800"
+                    }`}
+                  >
+                    {r.status.toUpperCase()}
+                  </span>
+                </div>
+                <span className="text-xs text-gray-500">
+                  {new Date(r.performed_at).toLocaleString()}
+                </span>
+              </div>
+              <div className="mt-1 flex gap-4 text-xs text-gray-500">
+                {r.pre_value != null && r.post_value != null && (
+                  <span>
+                    Pre: {r.pre_value} → Post: {r.post_value}
+                  </span>
+                )}
+                {r.method_reference && <span>Method: {r.method_reference}</span>}
+                {r.due_at && (
+                  <span>Next due: {new Date(r.due_at).toLocaleDateString()}</span>
+                )}
+              </div>
+              {r.corrective_action && (
+                <div className="mt-1 text-xs text-red-600">
+                  Corrective action: {r.corrective_action}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface Props {
+  facilityId: string;
+}
+
+export function InstrumentsView({ facilityId }: Props) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const { data: instruments, isLoading } = useQuery({
+    queryKey: ["instruments", facilityId],
+    queryFn: () => api.listInstrumentStatuses(facilityId),
+  });
+
+  if (isLoading) {
+    return <div className="py-8 text-center text-sm text-gray-500">Loading...</div>;
+  }
+
+  const overdueCount = instruments?.filter((i) => i.calibration_status === "overdue").length ?? 0;
+  const dueSoonCount = instruments?.filter((i) => i.calibration_status === "due_soon").length ?? 0;
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">
+          Instruments & Calibration
+        </h2>
+        <div className="flex gap-3 text-sm">
+          {overdueCount > 0 && (
+            <span className="font-medium text-red-600">
+              {overdueCount} overdue
+            </span>
+          )}
+          {dueSoonCount > 0 && (
+            <span className="font-medium text-yellow-600">
+              {dueSoonCount} due soon
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-gray-200">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Instrument
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Type
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Serial / Make
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Last Calibration
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Next Due
+              </th>
+              <th className="px-4 py-2 text-center text-xs font-medium uppercase text-gray-500">
+                Status
+              </th>
+              <th className="px-4 py-2 text-center text-xs font-medium uppercase text-gray-500">
+                History
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {instruments?.map((inst) => (
+              <TableRow
+                key={inst.id}
+                instrument={inst}
+                expanded={expandedId === inst.id}
+                onToggle={() =>
+                  setExpandedId(expandedId === inst.id ? null : inst.id)
+                }
+              />
+            ))}
+            {instruments?.length === 0 && (
+              <tr>
+                <td colSpan={7} className="py-8 text-center text-sm text-gray-400">
+                  No instruments configured
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {expandedId && (
+        <CalibrationHistory
+          instrumentId={expandedId}
+          instrumentName={instruments?.find((i) => i.id === expandedId)?.name ?? ""}
+        />
+      )}
+    </div>
+  );
+}
+
+function TableRow({
+  instrument: inst,
+  expanded,
+  onToggle,
+}: {
+  instrument: InstrumentStatus;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <tr className={`hover:bg-gray-50 ${inst.calibration_status === "overdue" ? "bg-red-50" : ""}`}>
+      <td className="px-4 py-2 text-sm font-medium text-gray-900">{inst.name}</td>
+      <td className="px-4 py-2 text-sm text-gray-600">{inst.instrument_type}</td>
+      <td className="px-4 py-2 text-sm text-gray-600">
+        {inst.serial_number && <div className="font-mono text-xs">{inst.serial_number}</div>}
+        {inst.manufacturer && inst.model && (
+          <div className="text-xs text-gray-400">
+            {inst.manufacturer} {inst.model}
+          </div>
+        )}
+      </td>
+      <td className="px-4 py-2 text-sm text-gray-600">
+        {inst.last_performed_at ? (
+          <div>
+            <div>{new Date(inst.last_performed_at).toLocaleDateString()}</div>
+            <div className="text-xs text-gray-400">
+              {inst.last_calibration_type} — {inst.last_status}
+            </div>
+          </div>
+        ) : (
+          <span className="text-gray-400">—</span>
+        )}
+      </td>
+      <td className="px-4 py-2 text-sm text-gray-600">
+        {inst.due_at ? new Date(inst.due_at).toLocaleDateString() : "—"}
+      </td>
+      <td className="px-4 py-2 text-center">
+        <CalStatusBadge status={inst.calibration_status} />
+      </td>
+      <td className="px-4 py-2 text-center">
+        <button
+          onClick={onToggle}
+          className={`rounded border px-2 py-1 text-xs ${
+            expanded
+              ? "border-blue-500 bg-blue-50 text-blue-600"
+              : "border-gray-300 text-gray-600 hover:bg-gray-100"
+          }`}
+        >
+          {expanded ? "Hide" : "View"}
+        </button>
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
## Summary
- **Instrument status endpoint** `GET /facilities/{id}/instruments` returns instruments with computed calibration status (current/due_soon/overdue/no_schedule), sorted with overdue first
- **Calibration history endpoint** `GET /instruments/{id}/calibrations` returns full history with pre/post values, pass/fail, method references
- **Instruments tab** on the facility dashboard with summary counts, status badges, and expandable calibration history

## New endpoints
| Method | Path | Description |
|---|---|---|
| GET | `/api/v1/facilities/{id}/instruments` | Instrument list with calibration status |
| GET | `/api/v1/instruments/{id}/calibrations` | Calibration history for an instrument |

## Test plan
- [x] WTP returns 3 instruments: pH Meter (overdue), Turbidimeter (overdue), Chlorine Analyzer (no schedule)
- [x] WWTP returns 2 instruments: both overdue
- [x] Calibration history for pH Meter #1 returns 1 record with pre/post values
- [x] Overdue instruments sorted first in results
- [x] Frontend TypeScript compiles clean
- [x] Full stack validated (Docker + Go + seed data + API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)