### PR TITLE
Add sample result create form

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -159,6 +159,22 @@ func (h *handler) listParameters(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, params)
 }
 
+func (h *handler) listUnits(w http.ResponseWriter, r *http.Request) {
+	orgID, err := parseUUID(r.PathValue("org_id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid org_id")
+		return
+	}
+
+	units, err := h.queries.ListUnits(r.Context(), orgID)
+	if err != nil {
+		slog.Error("list units", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, units)
+}
+
 func (h *handler) listSampleResults(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	filter := storage.SampleResultFilter{}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -22,6 +22,7 @@ func NewRouter(queries *storage.Queries, bus *events.Bus, jwtSecret string) http
 	protected.HandleFunc("GET /api/v1/organizations/{org_id}/facilities", h.listFacilities)
 	protected.HandleFunc("GET /api/v1/facilities/{facility_id}/monitoring-locations", h.listMonitoringLocations)
 	protected.HandleFunc("GET /api/v1/organizations/{org_id}/parameters", h.listParameters)
+	protected.HandleFunc("GET /api/v1/organizations/{org_id}/units", h.listUnits)
 	protected.HandleFunc("GET /api/v1/sample-results", h.listSampleResults)
 	protected.HandleFunc("POST /api/v1/sample-results", requireAnyRole([]string{"admin", "operator"}, h.createSampleResult))
 	protected.HandleFunc("PATCH /api/v1/sample-results/{id}/review", requireAnyRole([]string{"admin", "reviewer"}, h.reviewSampleResult))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,7 +2,9 @@ import type {
   Facility,
   MonitoringLocation,
   Parameter,
+  UnitOfMeasure,
   SampleResult,
+  CreateSampleResultInput,
   ComplianceResult,
   TrendingSeries,
   InstrumentStatus,
@@ -37,6 +39,15 @@ async function get<T>(path: string): Promise<T> {
   return handleResponse<T>(res);
 }
 
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<T>(res);
+}
+
 async function patch<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     method: "PATCH",
@@ -61,9 +72,17 @@ export const api = {
     return get<Parameter[]>(`/organizations/${orgId}/parameters`);
   },
 
+  listUnits(orgId: string) {
+    return get<UnitOfMeasure[]>(`/organizations/${orgId}/units`);
+  },
+
   listSampleResults(params: Record<string, string>) {
     const query = new URLSearchParams(params).toString();
     return get<SampleResult[]>(`/sample-results?${query}`);
+  },
+
+  createSampleResult(input: CreateSampleResultInput) {
+    return post<SampleResult>("/sample-results", input);
   },
 
   evaluateCompliance(facilityId: string) {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -35,6 +35,25 @@ export interface Parameter {
   updated_at: string;
 }
 
+export interface UnitOfMeasure {
+  id: string;
+  code: string;
+  name: string;
+}
+
+export interface CreateSampleResultInput {
+  monitoring_location_id: string;
+  parameter_id: string;
+  unit_id: string;
+  collected_at: string;
+  result_value?: number | null;
+  result_qualifier?: string;
+  detection_limit?: number;
+  entered_by: string;
+  source: string;
+  notes?: string;
+}
+
 export interface SampleResult {
   id: string;
   monitoring_location_id: string;

--- a/web/src/components/SampleResultForm.tsx
+++ b/web/src/components/SampleResultForm.tsx
@@ -1,0 +1,235 @@
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import type { CreateSampleResultInput, MonitoringLocation, Parameter, UnitOfMeasure } from "../api/types";
+
+interface Props {
+  facilityId: string;
+  orgId: string;
+  userId: string;
+  locations: MonitoringLocation[];
+  parameters: Parameter[];
+  onSubmit: (input: CreateSampleResultInput) => void;
+  onCancel: () => void;
+  isPending: boolean;
+  error?: string | null;
+}
+
+export function SampleResultForm({
+  facilityId,
+  orgId,
+  userId,
+  locations,
+  parameters,
+  onSubmit,
+  onCancel,
+  isPending,
+  error,
+}: Props) {
+  const [locationId, setLocationId] = useState("");
+  const [parameterId, setParameterId] = useState("");
+  const [unitId, setUnitId] = useState("");
+  const [collectedAt, setCollectedAt] = useState(
+    new Date().toISOString().slice(0, 16)
+  );
+  const [resultValue, setResultValue] = useState("");
+  const [resultQualifier, setResultQualifier] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const { data: units } = useQuery({
+    queryKey: ["units", orgId],
+    queryFn: () => api.listUnits(orgId),
+  });
+
+  const unitMap = new Map<string, UnitOfMeasure>(
+    units?.map((u) => [u.id, u]) ?? []
+  );
+
+  // Auto-select unit when parameter changes
+  useEffect(() => {
+    if (!parameterId) return;
+    const param = parameters.find((p) => p.id === parameterId);
+    if (param?.default_unit_id && unitMap.has(param.default_unit_id)) {
+      setUnitId(param.default_unit_id);
+    }
+  }, [parameterId, parameters, units]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const input: CreateSampleResultInput = {
+      monitoring_location_id: locationId,
+      parameter_id: parameterId,
+      unit_id: unitId,
+      collected_at: new Date(collectedAt).toISOString(),
+      entered_by: userId,
+      source: "manual",
+    };
+
+    if (resultQualifier) {
+      input.result_qualifier = resultQualifier;
+      if (resultValue) {
+        input.detection_limit = parseFloat(resultValue);
+      }
+    } else {
+      input.result_value = parseFloat(resultValue);
+    }
+
+    if (notes.trim()) {
+      input.notes = notes.trim();
+    }
+
+    onSubmit(input);
+  }
+
+  const isValid =
+    locationId &&
+    parameterId &&
+    unitId &&
+    collectedAt &&
+    (resultValue || resultQualifier);
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4"
+    >
+      <h3 className="mb-4 text-sm font-semibold text-gray-900">
+        New Sample Result
+      </h3>
+
+      {error && (
+        <div className="mb-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <label className="block">
+          <span className="text-xs font-medium text-gray-600">Location *</span>
+          <select
+            required
+            value={locationId}
+            onChange={(e) => setLocationId(e.target.value)}
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
+          >
+            <option value="">Select location...</option>
+            {locations.map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="text-xs font-medium text-gray-600">
+            Parameter *
+          </span>
+          <select
+            required
+            value={parameterId}
+            onChange={(e) => setParameterId(e.target.value)}
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
+          >
+            <option value="">Select parameter...</option>
+            {parameters.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name} ({p.code})
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="text-xs font-medium text-gray-600">Unit *</span>
+          <select
+            required
+            value={unitId}
+            onChange={(e) => setUnitId(e.target.value)}
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
+          >
+            <option value="">Select unit...</option>
+            {units?.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.code} — {u.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="text-xs font-medium text-gray-600">
+            Collected At *
+          </span>
+          <input
+            type="datetime-local"
+            required
+            value={collectedAt}
+            onChange={(e) => setCollectedAt(e.target.value)}
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-xs font-medium text-gray-600">
+            Result Value {resultQualifier ? "" : "*"}
+          </span>
+          <input
+            type="number"
+            step="any"
+            required={!resultQualifier}
+            value={resultValue}
+            onChange={(e) => setResultValue(e.target.value)}
+            placeholder="e.g. 7.2"
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm font-mono"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-xs font-medium text-gray-600">
+            Qualifier
+          </span>
+          <select
+            value={resultQualifier}
+            onChange={(e) => setResultQualifier(e.target.value)}
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
+          >
+            <option value="">None</option>
+            <option value="<">{"<"} (Below detection)</option>
+            <option value=">">{">"} (Above range)</option>
+            <option value="ND">ND (Not detected)</option>
+          </select>
+        </label>
+
+        <label className="block sm:col-span-2 lg:col-span-3">
+          <span className="text-xs font-medium text-gray-600">Notes</span>
+          <input
+            type="text"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Optional notes..."
+            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm"
+          />
+        </label>
+      </div>
+
+      <div className="mt-4 flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={!isValid || isPending}
+          className="rounded bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isPending ? "Saving..." : "Save Result"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border border-gray-300 px-4 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/components/SampleResultsTable.tsx
+++ b/web/src/components/SampleResultsTable.tsx
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { api } from "../api/client";
-import type { MonitoringLocation, Parameter, SampleResult } from "../api/types";
-import { type AuthUser, canReview, canApprove } from "../api/auth";
+import type { MonitoringLocation, Parameter, SampleResult, CreateSampleResultInput } from "../api/types";
+import { type AuthUser, canReview, canApprove, hasAnyRole } from "../api/auth";
 import { StatusBadge } from "./StatusBadge";
 import { AuditPanel } from "./AuditPanel";
+import { SampleResultForm } from "./SampleResultForm";
 
 interface Props {
   facilityId: string;
@@ -16,6 +17,8 @@ export function SampleResultsTable({ facilityId, orgId, user }: Props) {
   const queryClient = useQueryClient();
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [auditResultId, setAuditResultId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
 
   const { data: locations } = useQuery({
     queryKey: ["locations", facilityId],
@@ -67,6 +70,17 @@ export function SampleResultsTable({ facilityId, orgId, user }: Props) {
       queryClient.invalidateQueries({ queryKey: ["sample-results"] }),
   });
 
+  const createMutation = useMutation({
+    mutationFn: (input: CreateSampleResultInput) =>
+      api.createSampleResult(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sample-results"] });
+      setShowForm(false);
+      setCreateError(null);
+    },
+    onError: (err: Error) => setCreateError(err.message),
+  });
+
   const locMap = new Map<string, MonitoringLocation>(
     locations?.map((l) => [l.id, l]) ?? []
   );
@@ -85,17 +99,41 @@ export function SampleResultsTable({ facilityId, orgId, user }: Props) {
     <div>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-gray-900">Sample Results</h2>
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className="rounded border border-gray-300 px-3 py-1.5 text-sm"
-        >
-          <option value="">All statuses</option>
-          <option value="draft">Draft</option>
-          <option value="reviewed">Reviewed</option>
-          <option value="approved">Approved</option>
-        </select>
+        <div className="flex items-center gap-2">
+          {hasAnyRole(user, ["admin", "operator"]) && !showForm && (
+            <button
+              onClick={() => { setShowForm(true); setCreateError(null); }}
+              className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              + New Result
+            </button>
+          )}
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="rounded border border-gray-300 px-3 py-1.5 text-sm"
+          >
+            <option value="">All statuses</option>
+            <option value="draft">Draft</option>
+            <option value="reviewed">Reviewed</option>
+            <option value="approved">Approved</option>
+          </select>
+        </div>
       </div>
+
+      {showForm && locations && parameters && (
+        <SampleResultForm
+          facilityId={facilityId}
+          orgId={orgId}
+          userId={user.id}
+          locations={locations}
+          parameters={parameters}
+          onSubmit={(input) => createMutation.mutate(input)}
+          onCancel={() => { setShowForm(false); setCreateError(null); }}
+          isPending={createMutation.isPending}
+          error={createError}
+        />
+      )}
 
       {isLoading ? (
         <div className="py-8 text-center text-sm text-gray-500">Loading...</div>


### PR DESCRIPTION
## Summary
- Adds inline sample result entry form with "New Result" button on the Sample Results tab (visible to admin/operator roles)
- Form includes location, parameter, unit (auto-selected from parameter default), collected date, result value/qualifier, and notes
- Adds `GET /api/v1/organizations/{org_id}/units` endpoint to support the unit dropdown
- Adds `createSampleResult` and `listUnits` methods to the frontend API client

## Test plan
- [x] Log in as an operator (e.g. jmartinez@clearwater.gov) and verify "New Result" button appears
- [x] Log in as a viewer (e.g. tlee@clearwater.gov) and verify button is hidden
- [x] Fill out and submit the form — verify result appears in table with "draft" status
- [x] Verify unit auto-selects when choosing a parameter with a default unit
- [x] Verify validation prevents submission with missing required fields
- [x] Verify form can be cancelled without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)