### PR TITLE
Add configurable validation rules for data entry

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -291,7 +291,7 @@ func (h *handler) createSampleResult(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err == nil {
-		if rule.IsRequired && params.ResultValue == nil {
+		if rule.IsRequired && params.ResultValue == nil && params.ResultQualifier == nil {
 			writeError(w, http.StatusBadRequest, "a numeric result_value is required for this parameter")
 			return
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -175,6 +175,22 @@ func (h *handler) listUnits(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, units)
 }
 
+func (h *handler) listValidationRules(w http.ResponseWriter, r *http.Request) {
+	orgID, err := parseUUID(r.PathValue("org_id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid org_id")
+		return
+	}
+
+	rules, err := h.queries.ListValidationRules(r.Context(), orgID)
+	if err != nil {
+		slog.Error("list validation rules", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, rules)
+}
+
 func (h *handler) listSampleResults(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	filter := storage.SampleResultFilter{}
@@ -265,6 +281,31 @@ func (h *handler) createSampleResult(w http.ResponseWriter, r *http.Request) {
 	if params.ResultValue == nil && params.ResultQualifier == nil {
 		writeError(w, http.StatusBadRequest, "either result_value or result_qualifier is required")
 		return
+	}
+
+	// Validate result_value against configurable parameter rules.
+	rule, err := h.queries.GetValidationRule(r.Context(), params.ParameterID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		slog.Error("get validation rule", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if err == nil {
+		if rule.IsRequired && params.ResultValue == nil {
+			writeError(w, http.StatusBadRequest, "a numeric result_value is required for this parameter")
+			return
+		}
+		if params.ResultValue != nil {
+			v := *params.ResultValue
+			if rule.MinValue != nil && v < *rule.MinValue {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("result_value %.4g is below minimum %.4g", v, *rule.MinValue))
+				return
+			}
+			if rule.MaxValue != nil && v > *rule.MaxValue {
+				writeError(w, http.StatusBadRequest, fmt.Sprintf("result_value %.4g exceeds maximum %.4g", v, *rule.MaxValue))
+				return
+			}
+		}
 	}
 
 	result, err := h.queries.CreateSampleResult(r.Context(), params)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -23,6 +23,7 @@ func NewRouter(queries *storage.Queries, bus *events.Bus, jwtSecret string) http
 	protected.HandleFunc("GET /api/v1/facilities/{facility_id}/monitoring-locations", h.listMonitoringLocations)
 	protected.HandleFunc("GET /api/v1/organizations/{org_id}/parameters", h.listParameters)
 	protected.HandleFunc("GET /api/v1/organizations/{org_id}/units", h.listUnits)
+	protected.HandleFunc("GET /api/v1/organizations/{org_id}/validation-rules", h.listValidationRules)
 	protected.HandleFunc("GET /api/v1/sample-results", h.listSampleResults)
 	protected.HandleFunc("POST /api/v1/sample-results", requireAnyRole([]string{"admin", "operator"}, h.createSampleResult))
 	protected.HandleFunc("PATCH /api/v1/sample-results/{id}/review", requireAnyRole([]string{"admin", "reviewer"}, h.reviewSampleResult))

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -231,6 +231,45 @@ func (q *Queries) ListUnits(ctx context.Context, orgID uuid.UUID) ([]UnitOfMeasu
 	return pgx.CollectRows(rows, pgx.RowToStructByName[UnitOfMeasure])
 }
 
+// ValidationRule defines configurable validation constraints for a parameter.
+type ValidationRule struct {
+	ID              uuid.UUID `json:"id" db:"id"`
+	ParameterID     uuid.UUID `json:"parameter_id" db:"parameter_id"`
+	MinValue        *float64  `json:"min_value" db:"min_value"`
+	MaxValue        *float64  `json:"max_value" db:"max_value"`
+	PrecisionDigits *int16    `json:"precision_digits" db:"precision_digits"`
+	IsRequired      bool      `json:"is_required" db:"is_required"`
+	Active          bool      `json:"active" db:"active"`
+}
+
+// ListValidationRules returns all active validation rules for an organization's parameters.
+func (q *Queries) ListValidationRules(ctx context.Context, orgID uuid.UUID) ([]ValidationRule, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT vr.id, vr.parameter_id, vr.min_value, vr.max_value,
+		       vr.precision_digits, vr.is_required, vr.active
+		FROM validation_rules vr
+		JOIN parameters p ON p.id = vr.parameter_id
+		WHERE p.organization_id = $1 AND vr.active = true
+		ORDER BY p.code`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[ValidationRule])
+}
+
+// GetValidationRule returns the active validation rule for a specific parameter.
+func (q *Queries) GetValidationRule(ctx context.Context, parameterID uuid.UUID) (ValidationRule, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT id, parameter_id, min_value, max_value,
+		       precision_digits, is_required, active
+		FROM validation_rules
+		WHERE parameter_id = $1 AND active = true`, parameterID)
+	if err != nil {
+		return ValidationRule{}, err
+	}
+	return pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[ValidationRule])
+}
+
 // ListParameters returns all parameters for an organization.
 func (q *Queries) ListParameters(ctx context.Context, orgID uuid.UUID) ([]Parameter, error) {
 	rows, err := q.pool.Query(ctx, `

--- a/migrations/002_validation_rules.down.sql
+++ b/migrations/002_validation_rules.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS validation_rules;

--- a/migrations/002_validation_rules.up.sql
+++ b/migrations/002_validation_rules.up.sql
@@ -1,0 +1,16 @@
+-- Configurable validation rules per parameter.
+-- Each parameter can have a valid range (min/max) and precision constraint.
+-- These are enforced on sample result entry (both API and import).
+
+CREATE TABLE validation_rules (
+    id              UUID PRIMARY KEY,
+    parameter_id    UUID NOT NULL REFERENCES parameters(id),
+    min_value       DOUBLE PRECISION,       -- NULL means no lower bound
+    max_value       DOUBLE PRECISION,       -- NULL means no upper bound
+    precision_digits SMALLINT,              -- max decimal places allowed (NULL = no constraint)
+    is_required     BOOLEAN NOT NULL DEFAULT false,  -- whether a numeric value (not just qualifier) is required
+    active          BOOLEAN NOT NULL DEFAULT true,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(parameter_id)
+);

--- a/migrations/seed.sql
+++ b/migrations/seed.sql
@@ -209,3 +209,31 @@ INSERT INTO sample_results (id, monitoring_location_id, parameter_id, method_id,
 -- A non-detect result example (ammonia below detection limit)
 INSERT INTO sample_results (id, monitoring_location_id, parameter_id, method_id, unit_id, collected_at, result_value, result_qualifier, detection_limit, status, entered_by, reviewed_by, approved_by, reviewed_at, approved_at, source) VALUES
     ('019558a0-0010-7000-a000-000000000025', '019558a0-0005-7000-a000-000000000004', '019558a0-0007-7000-a000-000000000008', '019558a0-0008-7000-a000-000000000006', '019558a0-0006-7000-a000-000000000001', '2026-03-10 06:00:00-05', NULL, '<', 0.1, 'approved', '019558a0-0001-7000-a000-000000000002', '019558a0-0001-7000-a000-000000000003', '019558a0-0001-7000-a000-000000000003', '2026-03-10 14:00:00-05', '2026-03-10 16:00:00-05', 'manual');
+
+-- ============================================================================
+-- Validation Rules  (configurable range and precision per parameter)
+-- ============================================================================
+
+INSERT INTO validation_rules (id, parameter_id, min_value, max_value, precision_digits, is_required) VALUES
+    -- pH: 0-14, 2 decimal places
+    ('019558a0-0011-7000-a000-000000000001', '019558a0-0007-7000-a000-000000000001', 0,    14,      2, true),
+    -- Turbidity: 0-4000 NTU
+    ('019558a0-0011-7000-a000-000000000002', '019558a0-0007-7000-a000-000000000002', 0,    4000,    2, false),
+    -- Free Chlorine: 0-20 mg/L
+    ('019558a0-0011-7000-a000-000000000003', '019558a0-0007-7000-a000-000000000003', 0,    20,      2, false),
+    -- Total Chlorine: 0-25 mg/L
+    ('019558a0-0011-7000-a000-000000000004', '019558a0-0007-7000-a000-000000000004', 0,    25,      2, false),
+    -- Temperature: -5 to 50 degrees C
+    ('019558a0-0011-7000-a000-000000000005', '019558a0-0007-7000-a000-000000000005', -5,   50,      1, true),
+    -- BOD (5-day): 0-2000 mg/L
+    ('019558a0-0011-7000-a000-000000000006', '019558a0-0007-7000-a000-000000000006', 0,    2000,    1, false),
+    -- TSS: 0-5000 mg/L
+    ('019558a0-0011-7000-a000-000000000007', '019558a0-0007-7000-a000-000000000007', 0,    5000,    1, false),
+    -- Ammonia Nitrogen: 0-100 mg/L
+    ('019558a0-0011-7000-a000-000000000008', '019558a0-0007-7000-a000-000000000008', 0,    100,     2, false),
+    -- Dissolved Oxygen: 0-20 mg/L
+    ('019558a0-0011-7000-a000-000000000009', '019558a0-0007-7000-a000-000000000009', 0,    20,      2, false),
+    -- E. coli: 0-500000 CFU/100mL
+    ('019558a0-0011-7000-a000-000000000010', '019558a0-0007-7000-a000-000000000010', 0,    500000,  0, false),
+    -- Total Coliform: 0-500000 CFU/100mL
+    ('019558a0-0011-7000-a000-000000000011', '019558a0-0007-7000-a000-000000000011', 0,    500000,  0, false);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   MonitoringLocation,
   Parameter,
   UnitOfMeasure,
+  ValidationRule,
   SampleResult,
   CreateSampleResultInput,
   ComplianceResult,
@@ -74,6 +75,10 @@ export const api = {
 
   listUnits(orgId: string) {
     return get<UnitOfMeasure[]>(`/organizations/${orgId}/units`);
+  },
+
+  listValidationRules(orgId: string) {
+    return get<ValidationRule[]>(`/organizations/${orgId}/validation-rules`);
   },
 
   listSampleResults(params: Record<string, string>) {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -41,6 +41,16 @@ export interface UnitOfMeasure {
   name: string;
 }
 
+export interface ValidationRule {
+  id: string;
+  parameter_id: string;
+  min_value: number | null;
+  max_value: number | null;
+  precision_digits: number | null;
+  is_required: boolean;
+  active: boolean;
+}
+
 export interface CreateSampleResultInput {
   monitoring_location_id: string;
   parameter_id: string;

--- a/web/src/components/SampleResultForm.tsx
+++ b/web/src/components/SampleResultForm.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client";
-import type { CreateSampleResultInput, MonitoringLocation, Parameter, UnitOfMeasure } from "../api/types";
+import type { CreateSampleResultInput, MonitoringLocation, Parameter, UnitOfMeasure, ValidationRule } from "../api/types";
 
 interface Props {
   facilityId: string;
@@ -35,15 +35,31 @@ export function SampleResultForm({
   const [resultValue, setResultValue] = useState("");
   const [resultQualifier, setResultQualifier] = useState("");
   const [notes, setNotes] = useState("");
+  const [valueError, setValueError] = useState<string | null>(null);
 
   const { data: units } = useQuery({
     queryKey: ["units", orgId],
     queryFn: () => api.listUnits(orgId),
   });
 
+  const { data: validationRules } = useQuery({
+    queryKey: ["validation-rules", orgId],
+    queryFn: () => api.listValidationRules(orgId),
+  });
+
   const unitMap = new Map<string, UnitOfMeasure>(
     units?.map((u) => [u.id, u]) ?? []
   );
+
+  // Index rules by parameter_id for fast lookup
+  const ruleMap = useMemo(
+    () => new Map<string, ValidationRule>(
+      validationRules?.map((r) => [r.parameter_id, r]) ?? []
+    ),
+    [validationRules]
+  );
+
+  const activeRule = parameterId ? ruleMap.get(parameterId) : undefined;
 
   // Auto-select unit when parameter changes
   useEffect(() => {
@@ -54,8 +70,38 @@ export function SampleResultForm({
     }
   }, [parameterId, parameters, units]);
 
+  // Validate value against rules whenever it changes
+  useEffect(() => {
+    if (!resultValue || !activeRule) {
+      setValueError(null);
+      return;
+    }
+    const v = parseFloat(resultValue);
+    if (isNaN(v)) {
+      setValueError("Must be a number");
+      return;
+    }
+    if (activeRule.min_value !== null && v < activeRule.min_value) {
+      setValueError(`Below minimum (${activeRule.min_value})`);
+      return;
+    }
+    if (activeRule.max_value !== null && v > activeRule.max_value) {
+      setValueError(`Exceeds maximum (${activeRule.max_value})`);
+      return;
+    }
+    if (activeRule.precision_digits !== null) {
+      const parts = resultValue.split(".");
+      if (parts[1] && parts[1].length > activeRule.precision_digits) {
+        setValueError(`Max ${activeRule.precision_digits} decimal place(s)`);
+        return;
+      }
+    }
+    setValueError(null);
+  }, [resultValue, activeRule]);
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (valueError) return;
 
     const input: CreateSampleResultInput = {
       monitoring_location_id: locationId,
@@ -82,12 +128,32 @@ export function SampleResultForm({
     onSubmit(input);
   }
 
+  const isValueRequired = activeRule?.is_required && !resultQualifier;
+
   const isValid =
     locationId &&
     parameterId &&
     unitId &&
     collectedAt &&
-    (resultValue || resultQualifier);
+    (resultValue || resultQualifier) &&
+    !valueError;
+
+  // Build hint text for value field
+  function rangeHint(): string | null {
+    if (!activeRule) return null;
+    const parts: string[] = [];
+    if (activeRule.min_value !== null && activeRule.max_value !== null) {
+      parts.push(`Range: ${activeRule.min_value} – ${activeRule.max_value}`);
+    } else if (activeRule.min_value !== null) {
+      parts.push(`Min: ${activeRule.min_value}`);
+    } else if (activeRule.max_value !== null) {
+      parts.push(`Max: ${activeRule.max_value}`);
+    }
+    if (activeRule.precision_digits !== null) {
+      parts.push(`${activeRule.precision_digits} decimal(s)`);
+    }
+    return parts.length > 0 ? parts.join(" · ") : null;
+  }
 
   return (
     <form
@@ -171,20 +237,32 @@ export function SampleResultForm({
           />
         </label>
 
-        <label className="block">
-          <span className="text-xs font-medium text-gray-600">
-            Result Value {resultQualifier ? "" : "*"}
-          </span>
-          <input
-            type="number"
-            step="any"
-            required={!resultQualifier}
-            value={resultValue}
-            onChange={(e) => setResultValue(e.target.value)}
-            placeholder="e.g. 7.2"
-            className="mt-1 block w-full rounded border border-gray-300 px-3 py-1.5 text-sm font-mono"
-          />
-        </label>
+        <div className="block">
+          <label>
+            <span className="text-xs font-medium text-gray-600">
+              Result Value {isValueRequired ? "*" : resultQualifier ? "" : "*"}
+            </span>
+            <input
+              type="number"
+              step="any"
+              required={!resultQualifier}
+              value={resultValue}
+              onChange={(e) => setResultValue(e.target.value)}
+              placeholder="e.g. 7.2"
+              className={`mt-1 block w-full rounded border px-3 py-1.5 text-sm font-mono ${
+                valueError
+                  ? "border-red-400 bg-red-50"
+                  : "border-gray-300"
+              }`}
+            />
+          </label>
+          {valueError && (
+            <p className="mt-1 text-xs text-red-600">{valueError}</p>
+          )}
+          {!valueError && rangeHint() && (
+            <p className="mt-1 text-xs text-gray-400">{rangeHint()}</p>
+          )}
+        </div>
 
         <label className="block">
           <span className="text-xs font-medium text-gray-600">


### PR DESCRIPTION
## Summary
- Adds `validation_rules` table (migration 002) with per-parameter min/max range, precision digits, and required-value flag
- Backend enforces rules on `POST /sample-results`, rejecting out-of-range values with descriptive errors (e.g., "result_value 500 exceeds maximum 14")
- Frontend fetches rules via new `GET /organizations/{org_id}/validation-rules` endpoint and shows inline validation: red border + error message when out of range, gray hint text showing valid range below the input
- Seed data includes standard water quality ranges: pH (0-14), turbidity (0-4000 NTU), chlorine (0-20 mg/L), temperature (-5 to 50 C), BOD (0-2000), TSS (0-5000), ammonia (0-100), DO (0-20), E. coli/coliform (0-500000)

## Test plan
- [x] Run migration 002 against the database
- [x] Reseed with updated seed.sql to load validation rules
- [x] Select pH parameter in create form — verify "Range: 0 – 14 · 2 decimal(s)" hint appears
- [x] Enter pH value of 50 — verify red inline error "Exceeds maximum (14)"
- [x] Enter pH value of -1 — verify red inline error "Below minimum (0)"
- [x] Enter valid pH value of 7.2 — verify no error, form submits successfully
- [x] Enter pH value of 7.234 — verify precision error "Max 2 decimal place(s)"
- [x] Submit an out-of-range value via curl/API directly — verify backend returns 400
- [x] Select a qualifier (e.g., ND) — verify numeric value is no longer required

🤖 Generated with [Claude Code](https://claude.com/claude-code)