### PR TITLE
Add alerts and notifications system

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/carlos-loya/water-quality-data-management/internal/alerts"
 	"github.com/carlos-loya/water-quality-data-management/internal/api"
 	"github.com/carlos-loya/water-quality-data-management/internal/events"
 	"github.com/carlos-loya/water-quality-data-management/internal/storage"
@@ -22,6 +23,7 @@ func main() {
 	natsURL := envOr("NATS_URL", "nats://localhost:4222")
 	jwtSecret := envOr("JWT_SECRET", "dev-secret-change-in-production")
 	addr := envOr("ADDR", ":8080")
+	alertInterval := parseDuration(envOr("ALERT_EVAL_INTERVAL", "5m"), 5*time.Minute)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
@@ -52,6 +54,11 @@ func main() {
 	}
 
 	queries := storage.New(db)
+
+	// Start the alerts evaluator — scans exceedances + overdue calibrations on a ticker.
+	evaluator := alerts.NewEvaluator(queries, bus, alertInterval)
+	go evaluator.Run(ctx)
+
 	router := api.NewRouter(queries, bus, jwtSecret)
 
 	srv := &http.Server{
@@ -86,4 +93,13 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func parseDuration(s string, fallback time.Duration) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		slog.Warn("invalid duration, using fallback", "value", s, "fallback", fallback)
+		return fallback
+	}
+	return d
 }

--- a/internal/alerts/evaluator.go
+++ b/internal/alerts/evaluator.go
@@ -1,0 +1,235 @@
+// Package alerts provides a background evaluator that scans sample results
+// and instruments for conditions that warrant operator attention, and records
+// them as rows in the alerts table.
+//
+// The evaluator is idempotent: creating an alert for the same subject twice
+// while the first is still active is a no-op (the storage layer deduplicates
+// via a partial unique index). Creating an event is only emitted when a new
+// alert is actually inserted.
+package alerts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/carlos-loya/water-quality-data-management/internal/events"
+	"github.com/carlos-loya/water-quality-data-management/internal/storage"
+)
+
+// Store is the subset of storage.Store required by the evaluator.
+type Store interface {
+	ListAllFacilities(ctx context.Context) ([]storage.Facility, error)
+	ListFacilityExceedances(ctx context.Context, facilityID uuid.UUID) ([]storage.Exceedance, error)
+	ListInstrumentStatuses(ctx context.Context, facilityID uuid.UUID) ([]storage.InstrumentStatus, error)
+	CreateAlert(ctx context.Context, p storage.CreateAlertParams) (storage.Alert, bool, error)
+}
+
+// Publisher publishes change events. *events.Bus satisfies this.
+type Publisher interface {
+	Publish(event events.ChangeEvent) error
+}
+
+// Evaluator periodically checks for exceedances and overdue calibrations.
+type Evaluator struct {
+	store    Store
+	bus      Publisher
+	interval time.Duration
+}
+
+// NewEvaluator creates an evaluator with the given tick interval.
+// A zero or negative interval defaults to 5 minutes.
+func NewEvaluator(store Store, bus Publisher, interval time.Duration) *Evaluator {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	return &Evaluator{store: store, bus: bus, interval: interval}
+}
+
+// Run evaluates once immediately, then ticks until the context is cancelled.
+// Intended to be called in a goroutine. Errors are logged, not returned.
+func (e *Evaluator) Run(ctx context.Context) {
+	slog.Info("alerts evaluator started", "interval", e.interval)
+	e.tick(ctx)
+
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("alerts evaluator stopping")
+			return
+		case <-ticker.C:
+			e.tick(ctx)
+		}
+	}
+}
+
+func (e *Evaluator) tick(ctx context.Context) {
+	n, err := e.RunOnce(ctx)
+	if err != nil {
+		slog.Error("alerts evaluator tick failed", "error", err)
+		return
+	}
+	if n > 0 {
+		slog.Info("alerts evaluator created alerts", "count", n)
+	}
+}
+
+// RunOnce evaluates across all facilities exactly once and returns the number
+// of new alerts created. Duplicates (existing active alerts for the same
+// subject) are skipped silently.
+func (e *Evaluator) RunOnce(ctx context.Context) (int, error) {
+	facilities, err := e.store.ListAllFacilities(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list facilities: %w", err)
+	}
+
+	created := 0
+	for _, f := range facilities {
+		c, err := e.evaluateFacility(ctx, f)
+		if err != nil {
+			slog.Error("evaluate facility", "facility_id", f.ID, "error", err)
+			continue
+		}
+		created += c
+	}
+	return created, nil
+}
+
+func (e *Evaluator) evaluateFacility(ctx context.Context, f storage.Facility) (int, error) {
+	created := 0
+
+	// Exceedances
+	exceedances, err := e.store.ListFacilityExceedances(ctx, f.ID)
+	if err != nil {
+		return created, fmt.Errorf("list exceedances: %w", err)
+	}
+	for _, ex := range exceedances {
+		params := exceedanceAlertParams(ex)
+		alert, inserted, err := e.store.CreateAlert(ctx, params)
+		if err != nil {
+			slog.Error("create exceedance alert", "sample_result_id", ex.SampleResultID, "error", err)
+			continue
+		}
+		if inserted {
+			created++
+			e.publishAlertCreated(alert)
+		}
+	}
+
+	// Overdue calibrations
+	statuses, err := e.store.ListInstrumentStatuses(ctx, f.ID)
+	if err != nil {
+		return created, fmt.Errorf("list instrument statuses: %w", err)
+	}
+	for _, s := range statuses {
+		if s.CalibrationStatus != "overdue" {
+			continue
+		}
+		params := overdueCalibrationAlertParams(f, s)
+		alert, inserted, err := e.store.CreateAlert(ctx, params)
+		if err != nil {
+			slog.Error("create overdue calibration alert", "instrument_id", s.ID, "error", err)
+			continue
+		}
+		if inserted {
+			created++
+			e.publishAlertCreated(alert)
+		}
+	}
+
+	return created, nil
+}
+
+func (e *Evaluator) publishAlertCreated(a storage.Alert) {
+	if e.bus == nil {
+		return
+	}
+	newJSON, _ := json.Marshal(a)
+	event := events.ChangeEvent{
+		Subject:        events.SubjectAlertCreated,
+		Timestamp:      time.Now(),
+		OrganizationID: a.OrganizationID,
+		TableName:      "alerts",
+		RecordID:       a.ID,
+		Action:         "insert",
+		ChangedBy:      uuid.Nil, // system
+		NewValues:      newJSON,
+	}
+	if err := e.bus.Publish(event); err != nil {
+		slog.Error("publish alert event", "error", err, "alert_id", a.ID)
+	}
+}
+
+// exceedanceAlertParams derives the CreateAlertParams for a single exceedance.
+func exceedanceAlertParams(ex storage.Exceedance) storage.CreateAlertParams {
+	msg := fmt.Sprintf("%s at %s: %.4g %s exceeds %s of %.4g",
+		ex.ParameterName, ex.LocationName,
+		ex.ResultValue, ex.UnitCode,
+		ex.LimitType, ex.LimitValue)
+
+	details, _ := json.Marshal(map[string]any{
+		"parameter_code":         ex.ParameterCode,
+		"parameter_name":         ex.ParameterName,
+		"location_name":          ex.LocationName,
+		"monitoring_location_id": ex.MonitoringLocationID,
+		"result_value":           ex.ResultValue,
+		"unit_code":              ex.UnitCode,
+		"limit_type":             ex.LimitType,
+		"limit_value":            ex.LimitValue,
+		"collected_at":           ex.CollectedAt,
+	})
+
+	return storage.CreateAlertParams{
+		OrganizationID: ex.OrganizationID,
+		FacilityID:     ex.FacilityID,
+		Type:           "exceedance",
+		Severity:       "critical",
+		SubjectType:    "sample_result",
+		SubjectID:      ex.SampleResultID,
+		Message:        msg,
+		Details:        details,
+	}
+}
+
+// overdueCalibrationAlertParams derives the CreateAlertParams for an overdue instrument.
+// Severity is "warning" if overdue less than 7 days, otherwise "critical".
+func overdueCalibrationAlertParams(f storage.Facility, s storage.InstrumentStatus) storage.CreateAlertParams {
+	severity := "warning"
+	var daysOverdue int
+	if s.DueAt != nil {
+		elapsed := time.Since(*s.DueAt)
+		daysOverdue = int(math.Floor(elapsed.Hours() / 24))
+		if daysOverdue >= 7 {
+			severity = "critical"
+		}
+	}
+
+	msg := fmt.Sprintf("%s is %d day(s) overdue for calibration", s.Name, daysOverdue)
+
+	details, _ := json.Marshal(map[string]any{
+		"instrument_name":       s.Name,
+		"instrument_type":       s.InstrumentType,
+		"due_at":                s.DueAt,
+		"last_performed_at":     s.LastPerformedAt,
+		"last_calibration_type": s.LastCalibrationType,
+		"days_overdue":          daysOverdue,
+	})
+
+	return storage.CreateAlertParams{
+		OrganizationID: f.OrganizationID,
+		FacilityID:     f.ID,
+		Type:           "overdue_calibration",
+		Severity:       severity,
+		SubjectType:    "instrument",
+		SubjectID:      s.ID,
+		Message:        msg,
+		Details:        details,
+	}
+}

--- a/internal/alerts/evaluator_test.go
+++ b/internal/alerts/evaluator_test.go
@@ -1,0 +1,437 @@
+package alerts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/carlos-loya/water-quality-data-management/internal/events"
+	"github.com/carlos-loya/water-quality-data-management/internal/storage"
+)
+
+// ============================================================================
+// fakeStore — implements alerts.Store for evaluator tests.
+// ============================================================================
+
+type fakeStore struct {
+	mu sync.Mutex
+
+	facilities    []storage.Facility
+	exceedances   map[uuid.UUID][]storage.Exceedance
+	instruments   map[uuid.UUID][]storage.InstrumentStatus
+	existingByKey map[string]bool // dedupe key -> exists
+
+	createCalls []storage.CreateAlertParams
+	listFacErr  error
+	exErr       map[uuid.UUID]error
+	instErr     map[uuid.UUID]error
+	createErr   error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		exceedances:   make(map[uuid.UUID][]storage.Exceedance),
+		instruments:   make(map[uuid.UUID][]storage.InstrumentStatus),
+		existingByKey: make(map[string]bool),
+		exErr:         make(map[uuid.UUID]error),
+		instErr:       make(map[uuid.UUID]error),
+	}
+}
+
+func (s *fakeStore) ListAllFacilities(_ context.Context) ([]storage.Facility, error) {
+	return s.facilities, s.listFacErr
+}
+
+func (s *fakeStore) ListFacilityExceedances(_ context.Context, facilityID uuid.UUID) ([]storage.Exceedance, error) {
+	if err, ok := s.exErr[facilityID]; ok {
+		return nil, err
+	}
+	return s.exceedances[facilityID], nil
+}
+
+func (s *fakeStore) ListInstrumentStatuses(_ context.Context, facilityID uuid.UUID) ([]storage.InstrumentStatus, error) {
+	if err, ok := s.instErr[facilityID]; ok {
+		return nil, err
+	}
+	return s.instruments[facilityID], nil
+}
+
+func (s *fakeStore) CreateAlert(_ context.Context, p storage.CreateAlertParams) (storage.Alert, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.createErr != nil {
+		return storage.Alert{}, false, s.createErr
+	}
+
+	s.createCalls = append(s.createCalls, p)
+
+	key := dedupeKey(p)
+	if s.existingByKey[key] {
+		return storage.Alert{}, false, nil // duplicate; not inserted
+	}
+	s.existingByKey[key] = true
+
+	return storage.Alert{
+		ID:             uuid.New(),
+		OrganizationID: p.OrganizationID,
+		FacilityID:     p.FacilityID,
+		Type:           p.Type,
+		Severity:       p.Severity,
+		SubjectType:    p.SubjectType,
+		SubjectID:      p.SubjectID,
+		Message:        p.Message,
+		Details:        p.Details,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}, true, nil
+}
+
+func dedupeKey(p storage.CreateAlertParams) string {
+	return p.FacilityID.String() + "|" + p.Type + "|" + p.SubjectType + "|" + p.SubjectID.String()
+}
+
+// ============================================================================
+// fakePublisher
+// ============================================================================
+
+type fakePublisher struct {
+	mu        sync.Mutex
+	published []events.ChangeEvent
+	err       error
+}
+
+func (p *fakePublisher) Publish(e events.ChangeEvent) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.published = append(p.published, e)
+	return p.err
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+func facility(id, orgID uuid.UUID, name string) storage.Facility {
+	return storage.Facility{
+		ID:             id,
+		OrganizationID: orgID,
+		Name:           name,
+		FacilityType:   "water_treatment",
+		Active:         true,
+	}
+}
+
+func exceedance(facilityID, orgID uuid.UUID, resultValue, limitValue float64, limitType string) storage.Exceedance {
+	return storage.Exceedance{
+		SampleResultID:       uuid.New(),
+		MonitoringLocationID: uuid.New(),
+		FacilityID:           facilityID,
+		OrganizationID:       orgID,
+		LocationName:         "Effluent",
+		ParameterCode:        "PH",
+		ParameterName:        "pH",
+		ResultValue:          resultValue,
+		UnitCode:             "SU",
+		LimitType:            limitType,
+		LimitValue:           limitValue,
+		CollectedAt:          time.Now().Add(-24 * time.Hour),
+	}
+}
+
+func instrumentStatus(name, calStatus string, dueAt *time.Time) storage.InstrumentStatus {
+	return storage.InstrumentStatus{
+		ID:                uuid.New(),
+		Name:              name,
+		InstrumentType:    "benchtop",
+		Active:            true,
+		DueAt:             dueAt,
+		CalibrationStatus: calStatus,
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+func TestRunOnce_NoFacilities_NoAlerts(t *testing.T) {
+	s := newFakeStore()
+	p := &fakePublisher{}
+	e := NewEvaluator(s, p, time.Minute)
+
+	n, err := e.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 alerts, got %d", n)
+	}
+	if len(p.published) != 0 {
+		t.Fatalf("expected 0 published events, got %d", len(p.published))
+	}
+}
+
+func TestRunOnce_ExceedanceCreatesAlert(t *testing.T) {
+	s := newFakeStore()
+	facID := uuid.New()
+	orgID := uuid.New()
+	s.facilities = []storage.Facility{facility(facID, orgID, "North WTP")}
+	s.exceedances[facID] = []storage.Exceedance{
+		exceedance(facID, orgID, 9.2, 8.5, "daily_max"),
+	}
+
+	p := &fakePublisher{}
+	e := NewEvaluator(s, p, time.Minute)
+
+	n, err := e.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 alert, got %d", n)
+	}
+
+	if len(s.createCalls) != 1 {
+		t.Fatalf("expected 1 CreateAlert call, got %d", len(s.createCalls))
+	}
+	call := s.createCalls[0]
+	if call.Type != "exceedance" {
+		t.Errorf("expected type=exceedance, got %q", call.Type)
+	}
+	if call.Severity != "critical" {
+		t.Errorf("expected severity=critical, got %q", call.Severity)
+	}
+	if call.SubjectType != "sample_result" {
+		t.Errorf("expected subject_type=sample_result, got %q", call.SubjectType)
+	}
+	if call.FacilityID != facID {
+		t.Errorf("facility_id mismatch")
+	}
+	if call.OrganizationID != orgID {
+		t.Errorf("organization_id mismatch")
+	}
+	if call.Message == "" {
+		t.Errorf("expected non-empty message")
+	}
+
+	// Event published
+	if len(p.published) != 1 {
+		t.Fatalf("expected 1 published event, got %d", len(p.published))
+	}
+	if p.published[0].Subject != events.SubjectAlertCreated {
+		t.Errorf("expected subject=%s, got %s", events.SubjectAlertCreated, p.published[0].Subject)
+	}
+}
+
+func TestRunOnce_Dedupe_SkipsActiveDuplicate(t *testing.T) {
+	s := newFakeStore()
+	facID := uuid.New()
+	orgID := uuid.New()
+	s.facilities = []storage.Facility{facility(facID, orgID, "North WTP")}
+
+	// Same exceedance on two consecutive ticks.
+	ex := exceedance(facID, orgID, 9.2, 8.5, "daily_max")
+	s.exceedances[facID] = []storage.Exceedance{ex}
+
+	p := &fakePublisher{}
+	e := NewEvaluator(s, p, time.Minute)
+
+	n1, _ := e.RunOnce(context.Background())
+	n2, _ := e.RunOnce(context.Background())
+
+	if n1 != 1 {
+		t.Errorf("first run: expected 1 new alert, got %d", n1)
+	}
+	if n2 != 0 {
+		t.Errorf("second run: expected 0 new alerts (dedupe), got %d", n2)
+	}
+	// CreateAlert was called twice (evaluator always tries; storage dedupes).
+	if len(s.createCalls) != 2 {
+		t.Errorf("expected 2 CreateAlert calls, got %d", len(s.createCalls))
+	}
+	// But only one event published (dedupe suppresses event on second try).
+	if len(p.published) != 1 {
+		t.Errorf("expected 1 event, got %d", len(p.published))
+	}
+}
+
+func TestRunOnce_OverdueCalibration_SeverityByDaysOverdue(t *testing.T) {
+	cases := []struct {
+		name         string
+		overdueDays  int
+		wantSeverity string
+	}{
+		{"1 day overdue", 1, "warning"},
+		{"6 days overdue", 6, "warning"},
+		{"7 days overdue", 7, "critical"},
+		{"30 days overdue", 30, "critical"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newFakeStore()
+			facID := uuid.New()
+			orgID := uuid.New()
+			s.facilities = []storage.Facility{facility(facID, orgID, "South WWTP")}
+			dueAt := time.Now().Add(-time.Duration(tc.overdueDays) * 24 * time.Hour)
+			s.instruments[facID] = []storage.InstrumentStatus{
+				instrumentStatus("pH meter", "overdue", &dueAt),
+			}
+
+			e := NewEvaluator(s, &fakePublisher{}, time.Minute)
+			_, err := e.RunOnce(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(s.createCalls) != 1 {
+				t.Fatalf("expected 1 call, got %d", len(s.createCalls))
+			}
+			if got := s.createCalls[0].Severity; got != tc.wantSeverity {
+				t.Errorf("severity: expected %q, got %q", tc.wantSeverity, got)
+			}
+			if s.createCalls[0].Type != "overdue_calibration" {
+				t.Errorf("type: expected overdue_calibration, got %q", s.createCalls[0].Type)
+			}
+		})
+	}
+}
+
+func TestRunOnce_NonOverdueStatuses_NoAlert(t *testing.T) {
+	s := newFakeStore()
+	facID := uuid.New()
+	orgID := uuid.New()
+	s.facilities = []storage.Facility{facility(facID, orgID, "Plant")}
+	s.instruments[facID] = []storage.InstrumentStatus{
+		instrumentStatus("meter-1", "current", ptrTime(time.Now().Add(30*24*time.Hour))),
+		instrumentStatus("meter-2", "due_soon", ptrTime(time.Now().Add(24*time.Hour))),
+		instrumentStatus("meter-3", "no_schedule", nil),
+	}
+
+	e := NewEvaluator(s, &fakePublisher{}, time.Minute)
+	n, err := e.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 alerts, got %d", n)
+	}
+	if len(s.createCalls) != 0 {
+		t.Fatalf("expected 0 CreateAlert calls, got %d", len(s.createCalls))
+	}
+}
+
+func TestRunOnce_MultipleFacilities_IndependentCounts(t *testing.T) {
+	s := newFakeStore()
+	f1, f2 := uuid.New(), uuid.New()
+	orgID := uuid.New()
+	s.facilities = []storage.Facility{
+		facility(f1, orgID, "A"),
+		facility(f2, orgID, "B"),
+	}
+	s.exceedances[f1] = []storage.Exceedance{exceedance(f1, orgID, 9, 8, "daily_max")}
+	s.exceedances[f2] = []storage.Exceedance{
+		exceedance(f2, orgID, 10, 8, "daily_max"),
+		exceedance(f2, orgID, 11, 8, "daily_max"),
+	}
+
+	e := NewEvaluator(s, &fakePublisher{}, time.Minute)
+	n, err := e.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 alerts (1+2), got %d", n)
+	}
+}
+
+func TestRunOnce_FacilityError_ContinuesToOthers(t *testing.T) {
+	s := newFakeStore()
+	f1, f2 := uuid.New(), uuid.New()
+	orgID := uuid.New()
+	s.facilities = []storage.Facility{
+		facility(f1, orgID, "Failing"),
+		facility(f2, orgID, "Working"),
+	}
+	s.exErr[f1] = errors.New("db unavailable")
+	s.exceedances[f2] = []storage.Exceedance{exceedance(f2, orgID, 9, 8, "daily_max")}
+
+	e := NewEvaluator(s, &fakePublisher{}, time.Minute)
+	n, err := e.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error at top level: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 alert from working facility, got %d", n)
+	}
+}
+
+func TestRunOnce_ListAllFacilitiesError_Bubbles(t *testing.T) {
+	s := newFakeStore()
+	s.listFacErr = errors.New("boom")
+
+	e := NewEvaluator(s, &fakePublisher{}, time.Minute)
+	_, err := e.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRunOnce_ExceedanceDetailsPayload(t *testing.T) {
+	s := newFakeStore()
+	facID := uuid.New()
+	orgID := uuid.New()
+	s.facilities = []storage.Facility{facility(facID, orgID, "WTP")}
+	ex := exceedance(facID, orgID, 9.2, 8.5, "daily_max")
+	s.exceedances[facID] = []storage.Exceedance{ex}
+
+	e := NewEvaluator(s, &fakePublisher{}, time.Minute)
+	_, _ = e.RunOnce(context.Background())
+
+	if len(s.createCalls) != 1 {
+		t.Fatalf("expected 1 call")
+	}
+	var details map[string]any
+	if err := json.Unmarshal(s.createCalls[0].Details, &details); err != nil {
+		t.Fatalf("unmarshal details: %v", err)
+	}
+	if details["parameter_code"] != "PH" {
+		t.Errorf("parameter_code: got %v", details["parameter_code"])
+	}
+	if details["limit_type"] != "daily_max" {
+		t.Errorf("limit_type: got %v", details["limit_type"])
+	}
+}
+
+func TestNewEvaluator_DefaultInterval(t *testing.T) {
+	e := NewEvaluator(newFakeStore(), &fakePublisher{}, 0)
+	if e.interval != 5*time.Minute {
+		t.Errorf("expected default 5m, got %v", e.interval)
+	}
+	e2 := NewEvaluator(newFakeStore(), &fakePublisher{}, -1*time.Second)
+	if e2.interval != 5*time.Minute {
+		t.Errorf("expected default 5m for negative, got %v", e2.interval)
+	}
+}
+
+func TestRunOnce_NilBus_NoPanic(t *testing.T) {
+	s := newFakeStore()
+	facID := uuid.New()
+	orgID := uuid.New()
+	s.facilities = []storage.Facility{facility(facID, orgID, "WTP")}
+	s.exceedances[facID] = []storage.Exceedance{exceedance(facID, orgID, 9, 8, "daily_max")}
+
+	e := NewEvaluator(s, nil, time.Minute)
+	n, err := e.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1, got %d", n)
+	}
+}

--- a/internal/api/alerts_test.go
+++ b/internal/api/alerts_test.go
@@ -1,0 +1,378 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/carlos-loya/water-quality-data-management/internal/auth"
+	"github.com/carlos-loya/water-quality-data-management/internal/storage"
+)
+
+// ============================================================================
+// GET /api/v1/alerts
+// ============================================================================
+
+func TestListAlerts_OrgWideAdmin_ReturnsAll(t *testing.T) {
+	fac1, fac2 := uuid.New(), uuid.New()
+	store := &mockStore{
+		listAlertsFn: func(_ context.Context, _ storage.AlertFilter) ([]storage.Alert, error) {
+			return []storage.Alert{
+				{ID: uuid.New(), FacilityID: fac1, Type: "exceedance", Severity: "critical", Message: "a1"},
+				{ID: uuid.New(), FacilityID: fac2, Type: "overdue_calibration", Severity: "warning", Message: "a2"},
+			}, nil
+		},
+	}
+	h := &handler{store: store}
+
+	req := httptest.NewRequest("GET", "/api/v1/alerts", nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}}) // org-wide
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	arr := decodeArray(t, w.Body)
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(arr))
+	}
+}
+
+func TestListAlerts_FacilityScopedUser_FiltersResponse(t *testing.T) {
+	fac1, fac2 := uuid.New(), uuid.New()
+	store := &mockStore{
+		listAlertsFn: func(_ context.Context, _ storage.AlertFilter) ([]storage.Alert, error) {
+			return []storage.Alert{
+				{ID: uuid.New(), FacilityID: fac1, Type: "exceedance", Severity: "critical", Message: "a1"},
+				{ID: uuid.New(), FacilityID: fac2, Type: "exceedance", Severity: "critical", Message: "a2"},
+			}, nil
+		},
+	}
+	h := &handler{store: store}
+
+	req := httptest.NewRequest("GET", "/api/v1/alerts", nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "operator", FacilityID: fac1.String()}})
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	arr := decodeArray(t, w.Body)
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 alert (filtered by facility access), got %d", len(arr))
+	}
+	first := arr[0].(map[string]any)
+	if first["facility_id"] != fac1.String() {
+		t.Errorf("expected filtered alert to be for fac1, got %v", first["facility_id"])
+	}
+}
+
+func TestListAlerts_WithFacilityIDFilter_PassesToStore(t *testing.T) {
+	facID := uuid.New()
+	var received storage.AlertFilter
+	store := &mockStore{
+		listAlertsFn: func(_ context.Context, f storage.AlertFilter) ([]storage.Alert, error) {
+			received = f
+			return []storage.Alert{}, nil
+		},
+	}
+	h := &handler{store: store}
+
+	req := httptest.NewRequest("GET", "/api/v1/alerts?facility_id="+facID.String(), nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "operator", FacilityID: facID.String()}})
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+	if received.FacilityID == nil || *received.FacilityID != facID {
+		t.Errorf("expected filter.FacilityID=%s, got %v", facID, received.FacilityID)
+	}
+}
+
+func TestListAlerts_WithFacilityIDFilter_403WhenNoAccess(t *testing.T) {
+	facID := uuid.New()
+	store := &mockStore{}
+	h := &handler{store: store}
+
+	req := httptest.NewRequest("GET", "/api/v1/alerts?facility_id="+facID.String(), nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "operator", FacilityID: uuid.NewString()}}) // different facility
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestListAlerts_InvalidFacilityID_400(t *testing.T) {
+	h := &handler{store: &mockStore{}}
+
+	req := httptest.NewRequest("GET", "/api/v1/alerts?facility_id=not-a-uuid", nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListAlerts_InvalidType_400(t *testing.T) {
+	h := &handler{store: &mockStore{}}
+
+	req := httptest.NewRequest("GET", "/api/v1/alerts?type=weather", nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListAlerts_ValidType_PassesThrough(t *testing.T) {
+	var received storage.AlertFilter
+	store := &mockStore{
+		listAlertsFn: func(_ context.Context, f storage.AlertFilter) ([]storage.Alert, error) {
+			received = f
+			return []storage.Alert{}, nil
+		},
+	}
+	h := &handler{store: store}
+
+	req := httptest.NewRequest("GET", "/api/v1/alerts?type=exceedance", nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if received.Type == nil || *received.Type != "exceedance" {
+		t.Errorf("expected type=exceedance, got %v", received.Type)
+	}
+}
+
+func TestListAlerts_DismissedFilter(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{{"true", true}, {"false", false}}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			var received storage.AlertFilter
+			store := &mockStore{
+				listAlertsFn: func(_ context.Context, f storage.AlertFilter) ([]storage.Alert, error) {
+					received = f
+					return []storage.Alert{}, nil
+				},
+			}
+			h := &handler{store: store}
+			req := httptest.NewRequest("GET", "/api/v1/alerts?dismissed="+tc.in, nil)
+			req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+			w := httptest.NewRecorder()
+			h.listAlerts(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			if received.Dismissed == nil || *received.Dismissed != tc.want {
+				t.Errorf("expected dismissed=%v, got %v", tc.want, received.Dismissed)
+			}
+		})
+	}
+}
+
+func TestListAlerts_InvalidDismissed_400(t *testing.T) {
+	h := &handler{store: &mockStore{}}
+	req := httptest.NewRequest("GET", "/api/v1/alerts?dismissed=maybe", nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListAlerts_InvalidLimit_400(t *testing.T) {
+	h := &handler{store: &mockStore{}}
+	req := httptest.NewRequest("GET", "/api/v1/alerts?limit=-5", nil)
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListAlerts_Unauthenticated_401(t *testing.T) {
+	h := &handler{store: &mockStore{}}
+	req := httptest.NewRequest("GET", "/api/v1/alerts", nil) // no auth context
+	w := httptest.NewRecorder()
+	h.listAlerts(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+// ============================================================================
+// POST /api/v1/alerts/{id}/dismiss
+// ============================================================================
+
+func TestDismissAlert_HappyPath(t *testing.T) {
+	alertID := uuid.New()
+	facID := uuid.New()
+	store := &mockStore{
+		getAlertFn: func(_ context.Context, id uuid.UUID) (storage.Alert, error) {
+			if id != alertID {
+				return storage.Alert{}, pgx.ErrNoRows
+			}
+			return storage.Alert{ID: alertID, FacilityID: facID, Type: "exceedance", Severity: "critical", Message: "msg"}, nil
+		},
+		dismissAlertFn: func(_ context.Context, id, userID uuid.UUID) (storage.Alert, error) {
+			return storage.Alert{ID: id, FacilityID: facID, Type: "exceedance", Severity: "critical", Message: "msg", DismissedBy: &userID}, nil
+		},
+	}
+	h := &handler{store: store}
+
+	req := httptest.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/dismiss", nil)
+	req.SetPathValue("id", alertID.String())
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "operator", FacilityID: facID.String()}})
+	w := httptest.NewRecorder()
+	h.dismissAlert(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["dismissed_by"] == nil {
+		t.Error("expected dismissed_by to be set in response")
+	}
+}
+
+func TestDismissAlert_InvalidUUID_400(t *testing.T) {
+	h := &handler{store: &mockStore{}}
+	req := httptest.NewRequest("POST", "/api/v1/alerts/not-a-uuid/dismiss", nil)
+	req.SetPathValue("id", "not-a-uuid")
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "operator"}})
+	w := httptest.NewRecorder()
+	h.dismissAlert(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestDismissAlert_NotFound_404(t *testing.T) {
+	store := &mockStore{
+		getAlertFn: func(_ context.Context, _ uuid.UUID) (storage.Alert, error) {
+			return storage.Alert{}, pgx.ErrNoRows
+		},
+	}
+	h := &handler{store: store}
+	id := uuid.New()
+	req := httptest.NewRequest("POST", "/api/v1/alerts/"+id.String()+"/dismiss", nil)
+	req.SetPathValue("id", id.String())
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+	w := httptest.NewRecorder()
+	h.dismissAlert(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestDismissAlert_NoFacilityAccess_403(t *testing.T) {
+	alertID := uuid.New()
+	facID := uuid.New()
+	store := &mockStore{
+		getAlertFn: func(_ context.Context, _ uuid.UUID) (storage.Alert, error) {
+			return storage.Alert{ID: alertID, FacilityID: facID}, nil
+		},
+	}
+	h := &handler{store: store}
+	req := httptest.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/dismiss", nil)
+	req.SetPathValue("id", alertID.String())
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "operator", FacilityID: uuid.NewString()}}) // wrong facility
+	w := httptest.NewRecorder()
+	h.dismissAlert(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestDismissAlert_AlreadyDismissed_409(t *testing.T) {
+	alertID := uuid.New()
+	facID := uuid.New()
+	store := &mockStore{
+		getAlertFn: func(_ context.Context, _ uuid.UUID) (storage.Alert, error) {
+			return storage.Alert{ID: alertID, FacilityID: facID}, nil
+		},
+		dismissAlertFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID) (storage.Alert, error) {
+			return storage.Alert{}, pgx.ErrNoRows
+		},
+	}
+	h := &handler{store: store}
+	req := httptest.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/dismiss", nil)
+	req.SetPathValue("id", alertID.String())
+	req = withAuthCtx(req, []auth.RoleClaim{{Role: "admin"}})
+	w := httptest.NewRecorder()
+	h.dismissAlert(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+}
+
+// ============================================================================
+// RBAC on the dismiss route — viewer must be blocked before reaching handler.
+// This exercises the router-level requireAnyRole wrapper.
+// ============================================================================
+
+func TestDismissAlert_ViewerForbidden_ViaRouter(t *testing.T) {
+	alertID := uuid.New()
+	store := &mockStore{} // not expected to be called
+	router := NewRouter(store, nil, testSecret)
+
+	token := makeToken(t, []auth.RoleClaim{{Role: "viewer"}})
+	req := httptest.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/dismiss", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (viewers cannot dismiss); body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestDismissAlert_OperatorAllowed_ViaRouter(t *testing.T) {
+	alertID := uuid.New()
+	facID := uuid.New()
+	store := &mockStore{
+		getAlertFn: func(_ context.Context, _ uuid.UUID) (storage.Alert, error) {
+			return storage.Alert{ID: alertID, FacilityID: facID}, nil
+		},
+		dismissAlertFn: func(_ context.Context, id, userID uuid.UUID) (storage.Alert, error) {
+			return storage.Alert{ID: id, FacilityID: facID, DismissedBy: &userID}, nil
+		},
+	}
+	router := NewRouter(store, nil, testSecret)
+
+	token := makeToken(t, []auth.RoleClaim{{Role: "operator", FacilityID: facID.String()}})
+	req := httptest.NewRequest("POST", "/api/v1/alerts/"+alertID.String()+"/dismiss", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -47,6 +47,12 @@ type mockStore struct {
 	listCalibrationRecordsFn   func(ctx context.Context, instrumentID uuid.UUID) ([]storage.CalibrationRecord, error)
 	getOrganizationIDForResFn  func(ctx context.Context, resultID uuid.UUID) (uuid.UUID, error)
 	listAuditLogFn             func(ctx context.Context, recordID uuid.UUID) ([]storage.AuditEntry, error)
+	listAllFacilitiesFn        func(ctx context.Context) ([]storage.Facility, error)
+	listFacilityExceedancesFn  func(ctx context.Context, facilityID uuid.UUID) ([]storage.Exceedance, error)
+	createAlertFn              func(ctx context.Context, p storage.CreateAlertParams) (storage.Alert, bool, error)
+	listAlertsFn               func(ctx context.Context, f storage.AlertFilter) ([]storage.Alert, error)
+	getAlertFn                 func(ctx context.Context, id uuid.UUID) (storage.Alert, error)
+	dismissAlertFn             func(ctx context.Context, id, userID uuid.UUID) (storage.Alert, error)
 }
 
 func (m *mockStore) GetUserByEmail(ctx context.Context, email string) (storage.User, error) {
@@ -199,6 +205,48 @@ func (m *mockStore) ListAuditLog(ctx context.Context, recordID uuid.UUID) ([]sto
 		return m.listAuditLogFn(ctx, recordID)
 	}
 	return nil, nil
+}
+
+func (m *mockStore) ListAllFacilities(ctx context.Context) ([]storage.Facility, error) {
+	if m.listAllFacilitiesFn != nil {
+		return m.listAllFacilitiesFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockStore) ListFacilityExceedances(ctx context.Context, facilityID uuid.UUID) ([]storage.Exceedance, error) {
+	if m.listFacilityExceedancesFn != nil {
+		return m.listFacilityExceedancesFn(ctx, facilityID)
+	}
+	return nil, nil
+}
+
+func (m *mockStore) CreateAlert(ctx context.Context, p storage.CreateAlertParams) (storage.Alert, bool, error) {
+	if m.createAlertFn != nil {
+		return m.createAlertFn(ctx, p)
+	}
+	return storage.Alert{}, false, nil
+}
+
+func (m *mockStore) ListAlerts(ctx context.Context, f storage.AlertFilter) ([]storage.Alert, error) {
+	if m.listAlertsFn != nil {
+		return m.listAlertsFn(ctx, f)
+	}
+	return nil, nil
+}
+
+func (m *mockStore) GetAlert(ctx context.Context, id uuid.UUID) (storage.Alert, error) {
+	if m.getAlertFn != nil {
+		return m.getAlertFn(ctx, id)
+	}
+	return storage.Alert{}, pgx.ErrNoRows
+}
+
+func (m *mockStore) DismissAlert(ctx context.Context, id, userID uuid.UUID) (storage.Alert, error) {
+	if m.dismissAlertFn != nil {
+		return m.dismissAlertFn(ctx, id, userID)
+	}
+	return storage.Alert{}, pgx.ErrNoRows
 }
 
 // =========================================================================

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -597,6 +597,149 @@ func (h *handler) importSampleResults(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
+// ============================================================================
+// Alerts
+// ============================================================================
+
+func (h *handler) listAlerts(w http.ResponseWriter, r *http.Request) {
+	claims := auth.UserFrom(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+
+	q := r.URL.Query()
+	filter := storage.AlertFilter{}
+
+	if v := q.Get("facility_id"); v != "" {
+		id, err := parseUUID(v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid facility_id")
+			return
+		}
+		if !claims.HasFacilityAccess(id.String()) {
+			writeError(w, http.StatusForbidden, "no access to this facility")
+			return
+		}
+		filter.FacilityID = &id
+	}
+	if v := q.Get("type"); v != "" {
+		if v != "exceedance" && v != "overdue_calibration" {
+			writeError(w, http.StatusBadRequest, "invalid type")
+			return
+		}
+		filter.Type = &v
+	}
+	if v := q.Get("dismissed"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid dismissed, expected true/false")
+			return
+		}
+		filter.Dismissed = &b
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "invalid limit")
+			return
+		}
+		filter.Limit = n
+	}
+
+	alerts, err := h.store.ListAlerts(r.Context(), filter)
+	if err != nil {
+		slog.Error("list alerts", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// If the caller didn't scope by facility, filter the response to facilities
+	// the user has access to. Admins with org-wide roles see everything.
+	if filter.FacilityID == nil {
+		filtered := make([]storage.Alert, 0, len(alerts))
+		for _, a := range alerts {
+			if claims.HasFacilityAccess(a.FacilityID.String()) {
+				filtered = append(filtered, a)
+			}
+		}
+		alerts = filtered
+	}
+
+	writeJSON(w, http.StatusOK, alerts)
+}
+
+func (h *handler) dismissAlert(w http.ResponseWriter, r *http.Request) {
+	id, err := parseUUID(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	claims := auth.UserFrom(r.Context())
+	if claims == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+
+	existing, err := h.store.GetAlert(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "alert not found")
+			return
+		}
+		slog.Error("get alert", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if !claims.HasFacilityAccess(existing.FacilityID.String()) {
+		writeError(w, http.StatusForbidden, "no access to this facility")
+		return
+	}
+
+	after, err := h.store.DismissAlert(r.Context(), id, claims.UserID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusConflict, "alert is already dismissed")
+			return
+		}
+		slog.Error("dismiss alert", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	h.publishAlertEvent(events.SubjectAlertDismissed, "update", after, &existing)
+	writeJSON(w, http.StatusOK, after)
+}
+
+// publishAlertEvent sends an alert change event to the bus for audit logging.
+func (h *handler) publishAlertEvent(subject, action string, after storage.Alert, before *storage.Alert) {
+	if h.bus == nil {
+		return
+	}
+	newJSON, _ := json.Marshal(after)
+	event := events.ChangeEvent{
+		Subject:        subject,
+		Timestamp:      time.Now(),
+		OrganizationID: after.OrganizationID,
+		TableName:      "alerts",
+		RecordID:       after.ID,
+		Action:         action,
+		ChangedBy:      uuid.Nil,
+		NewValues:      newJSON,
+	}
+	if before != nil {
+		oldJSON, _ := json.Marshal(*before)
+		event.OldValues = oldJSON
+	}
+	if after.DismissedBy != nil {
+		event.ChangedBy = *after.DismissedBy
+	}
+	if err := h.bus.Publish(event); err != nil {
+		slog.Error("publish alert event", "error", err, "subject", subject)
+	}
+}
+
 // publishResultEvent sends a change event for a sample result to NATS.
 // Failures are logged but do not block the HTTP response.
 func (h *handler) publishResultEvent(ctx context.Context, subject, action string, result storage.SampleResult, before *storage.SampleResult) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -36,6 +36,8 @@ func NewRouter(store storage.Store, bus *events.Bus, jwtSecret string) http.Hand
 	protected.HandleFunc("GET /api/v1/facilities/{facility_id}/reports/compliance.xlsx", h.complianceExcel)
 	protected.HandleFunc("GET /api/v1/facilities/{facility_id}/reports/compliance.pdf", h.compliancePDF)
 	protected.HandleFunc("GET /api/v1/audit-log/{record_id}", h.listAuditLog)
+	protected.HandleFunc("GET /api/v1/alerts", h.listAlerts)
+	protected.HandleFunc("POST /api/v1/alerts/{id}/dismiss", requireAnyRole([]string{"admin", "operator", "reviewer"}, h.dismissAlert))
 
 	mux.Handle("/api/v1/", withAuth(jwtSecret, protected))
 

--- a/internal/events/audit.go
+++ b/internal/events/audit.go
@@ -15,16 +15,17 @@ type AuditConsumer struct {
 }
 
 // NewAuditConsumer creates and starts the audit log consumer.
-// It subscribes to all sample_result.* events.
+// It subscribes to sample_result.* and alert.* events.
 func NewAuditConsumer(pool *pgxpool.Pool, bus *Bus) (*AuditConsumer, error) {
 	c := &AuditConsumer{pool: pool, bus: bus}
 
-	_, err := bus.Subscribe("sample_result.*", c.handle)
-	if err != nil {
-		return nil, err
+	for _, subject := range []string{"sample_result.*", "alert.*"} {
+		if _, err := bus.Subscribe(subject, c.handle); err != nil {
+			return nil, err
+		}
+		slog.Info("audit consumer subscribed", "subject", subject)
 	}
 
-	slog.Info("audit consumer started", "subject", "sample_result.*")
 	return c, nil
 }
 

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -15,6 +15,8 @@ const (
 	SubjectSampleResultCreated  = "sample_result.created"
 	SubjectSampleResultReviewed = "sample_result.reviewed"
 	SubjectSampleResultApproved = "sample_result.approved"
+	SubjectAlertCreated         = "alert.created"
+	SubjectAlertDismissed       = "alert.dismissed"
 )
 
 // ChangeEvent represents a data change published to the event bus.

--- a/internal/ingestion/csv_test.go
+++ b/internal/ingestion/csv_test.go
@@ -113,6 +113,24 @@ func (m *mockStore) GetOrganizationIDForResult(context.Context, uuid.UUID) (uuid
 func (m *mockStore) ListAuditLog(context.Context, uuid.UUID) ([]storage.AuditEntry, error) {
 	panic("not implemented")
 }
+func (m *mockStore) ListAllFacilities(context.Context) ([]storage.Facility, error) {
+	panic("not implemented")
+}
+func (m *mockStore) ListFacilityExceedances(context.Context, uuid.UUID) ([]storage.Exceedance, error) {
+	panic("not implemented")
+}
+func (m *mockStore) CreateAlert(context.Context, storage.CreateAlertParams) (storage.Alert, bool, error) {
+	panic("not implemented")
+}
+func (m *mockStore) ListAlerts(context.Context, storage.AlertFilter) ([]storage.Alert, error) {
+	panic("not implemented")
+}
+func (m *mockStore) GetAlert(context.Context, uuid.UUID) (storage.Alert, error) {
+	panic("not implemented")
+}
+func (m *mockStore) DismissAlert(context.Context, uuid.UUID, uuid.UUID) (storage.Alert, error) {
+	panic("not implemented")
+}
 
 // --- test fixtures ---
 

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -753,4 +754,232 @@ func (q *Queries) GetOrganizationIDForResult(ctx context.Context, resultID uuid.
 		JOIN facilities f ON ml.facility_id = f.id
 		WHERE sr.id = $1`, resultID).Scan(&orgID)
 	return orgID, err
+}
+
+// ListAllFacilities returns every active facility across all organizations.
+// Used by the alerts evaluator, which has no user context.
+func (q *Queries) ListAllFacilities(ctx context.Context) ([]Facility, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT id, organization_id, name, facility_type, address, latitude, longitude, active, created_at, updated_at
+		FROM facilities
+		WHERE active = true
+		ORDER BY organization_id, name`)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[Facility])
+}
+
+// Exceedance describes a sample result that violates a currently effective permit limit.
+// Purpose-built for the alerts evaluator — carries the IDs needed to create a targeted alert.
+type Exceedance struct {
+	SampleResultID       uuid.UUID `json:"sample_result_id" db:"sample_result_id"`
+	MonitoringLocationID uuid.UUID `json:"monitoring_location_id" db:"monitoring_location_id"`
+	FacilityID           uuid.UUID `json:"facility_id" db:"facility_id"`
+	OrganizationID       uuid.UUID `json:"organization_id" db:"organization_id"`
+	LocationName         string    `json:"location_name" db:"location_name"`
+	ParameterCode        string    `json:"parameter_code" db:"parameter_code"`
+	ParameterName        string    `json:"parameter_name" db:"parameter_name"`
+	ResultValue          float64   `json:"result_value" db:"result_value"`
+	UnitCode             string    `json:"unit_code" db:"unit_code"`
+	LimitType            string    `json:"limit_type" db:"limit_type"`
+	LimitValue           float64   `json:"limit_value" db:"limit_value"`
+	CollectedAt          time.Time `json:"collected_at" db:"collected_at"`
+}
+
+// ListFacilityExceedances returns sample results that currently exceed an effective permit limit.
+// Rows with NULL result_value are excluded (non-detects can't exceed a numeric limit).
+func (q *Queries) ListFacilityExceedances(ctx context.Context, facilityID uuid.UUID) ([]Exceedance, error) {
+	rows, err := q.pool.Query(ctx, `
+		SELECT sr.id AS sample_result_id,
+		       ml.id AS monitoring_location_id,
+		       f.id  AS facility_id,
+		       f.organization_id,
+		       ml.name AS location_name,
+		       p.code  AS parameter_code,
+		       p.name  AS parameter_name,
+		       sr.result_value,
+		       u.code  AS unit_code,
+		       pl.limit_type, pl.limit_value,
+		       sr.collected_at
+		FROM sample_results sr
+		JOIN monitoring_locations ml ON sr.monitoring_location_id = ml.id
+		JOIN facilities f             ON ml.facility_id = f.id
+		JOIN parameters p             ON sr.parameter_id = p.id
+		JOIN units_of_measure u       ON sr.unit_id = u.id
+		JOIN permit_limits pl         ON pl.monitoring_location_id = sr.monitoring_location_id
+		    AND pl.parameter_id = sr.parameter_id
+		    AND sr.collected_at::date >= pl.effective_start
+		    AND (pl.effective_end IS NULL OR sr.collected_at::date <= pl.effective_end)
+		WHERE f.id = $1
+		  AND sr.result_value IS NOT NULL
+		  AND (
+		      (pl.limit_type LIKE '%max%' AND sr.result_value > pl.limit_value) OR
+		      (pl.limit_type LIKE '%min%' AND sr.result_value < pl.limit_value)
+		  )`, facilityID)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[Exceedance])
+}
+
+// ============================================================================
+// Alerts
+// ============================================================================
+
+// Alert represents a notification about a compliance or operational condition.
+type Alert struct {
+	ID             uuid.UUID       `json:"id"`
+	OrganizationID uuid.UUID       `json:"organization_id"`
+	FacilityID     uuid.UUID       `json:"facility_id"`
+	Type           string          `json:"type"`
+	Severity       string          `json:"severity"`
+	SubjectType    string          `json:"subject_type"`
+	SubjectID      uuid.UUID       `json:"subject_id"`
+	Message        string          `json:"message"`
+	Details        json.RawMessage `json:"details,omitempty"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
+	DismissedAt    *time.Time      `json:"dismissed_at,omitempty"`
+	DismissedBy    *uuid.UUID      `json:"dismissed_by,omitempty"`
+}
+
+// AlertFilter controls which alerts are returned by ListAlerts.
+type AlertFilter struct {
+	FacilityID *uuid.UUID
+	Type       *string
+	Dismissed  *bool // nil = any state
+	Limit      int
+}
+
+// CreateAlertParams is the input for CreateAlert.
+type CreateAlertParams struct {
+	OrganizationID uuid.UUID
+	FacilityID     uuid.UUID
+	Type           string
+	Severity       string
+	SubjectType    string
+	SubjectID      uuid.UUID
+	Message        string
+	Details        json.RawMessage
+}
+
+// CreateAlert inserts a new alert. If an active (not dismissed) alert already exists
+// for the same (facility, type, subject), the insert is skipped and `created` is false.
+// The partial unique index `alerts_active_subject_idx` enforces this at the DB level.
+func (q *Queries) CreateAlert(ctx context.Context, p CreateAlertParams) (Alert, bool, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return Alert{}, false, fmt.Errorf("generate uuid: %w", err)
+	}
+
+	var a Alert
+	err = q.pool.QueryRow(ctx, `
+		INSERT INTO alerts (id, organization_id, facility_id, type, severity, subject_type, subject_id, message, details)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (facility_id, type, subject_type, subject_id) WHERE dismissed_at IS NULL
+		DO NOTHING
+		RETURNING id, organization_id, facility_id, type, severity, subject_type, subject_id,
+		          message, details, created_at, updated_at, dismissed_at, dismissed_by`,
+		id, p.OrganizationID, p.FacilityID, p.Type, p.Severity, p.SubjectType, p.SubjectID, p.Message, p.Details,
+	).Scan(
+		&a.ID, &a.OrganizationID, &a.FacilityID, &a.Type, &a.Severity, &a.SubjectType, &a.SubjectID,
+		&a.Message, &a.Details, &a.CreatedAt, &a.UpdatedAt, &a.DismissedAt, &a.DismissedBy,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Active duplicate — not an error. Caller decides what to do.
+		return Alert{}, false, nil
+	}
+	if err != nil {
+		return Alert{}, false, err
+	}
+	return a, true, nil
+}
+
+// ListAlerts returns alerts matching the filter, newest first.
+func (q *Queries) ListAlerts(ctx context.Context, f AlertFilter) ([]Alert, error) {
+	query := `
+		SELECT id, organization_id, facility_id, type, severity, subject_type, subject_id,
+		       message, details, created_at, updated_at, dismissed_at, dismissed_by
+		FROM alerts
+		WHERE 1=1`
+	args := []any{}
+	argN := 1
+
+	if f.FacilityID != nil {
+		query += fmt.Sprintf(" AND facility_id = $%d", argN)
+		args = append(args, *f.FacilityID)
+		argN++
+	}
+	if f.Type != nil {
+		query += fmt.Sprintf(" AND type = $%d", argN)
+		args = append(args, *f.Type)
+		argN++
+	}
+	if f.Dismissed != nil {
+		if *f.Dismissed {
+			query += " AND dismissed_at IS NOT NULL"
+		} else {
+			query += " AND dismissed_at IS NULL"
+		}
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	limit := f.Limit
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	query += fmt.Sprintf(" LIMIT $%d", argN)
+	args = append(args, limit)
+
+	rows, err := q.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	alerts := make([]Alert, 0)
+	for rows.Next() {
+		var a Alert
+		if err := rows.Scan(
+			&a.ID, &a.OrganizationID, &a.FacilityID, &a.Type, &a.Severity, &a.SubjectType, &a.SubjectID,
+			&a.Message, &a.Details, &a.CreatedAt, &a.UpdatedAt, &a.DismissedAt, &a.DismissedBy,
+		); err != nil {
+			return nil, err
+		}
+		alerts = append(alerts, a)
+	}
+	return alerts, rows.Err()
+}
+
+// GetAlert retrieves a single alert by ID.
+func (q *Queries) GetAlert(ctx context.Context, id uuid.UUID) (Alert, error) {
+	var a Alert
+	err := q.pool.QueryRow(ctx, `
+		SELECT id, organization_id, facility_id, type, severity, subject_type, subject_id,
+		       message, details, created_at, updated_at, dismissed_at, dismissed_by
+		FROM alerts
+		WHERE id = $1`, id,
+	).Scan(
+		&a.ID, &a.OrganizationID, &a.FacilityID, &a.Type, &a.Severity, &a.SubjectType, &a.SubjectID,
+		&a.Message, &a.Details, &a.CreatedAt, &a.UpdatedAt, &a.DismissedAt, &a.DismissedBy,
+	)
+	return a, err
+}
+
+// DismissAlert marks an alert as dismissed by the given user.
+// Returns the updated alert. If the alert is already dismissed, returns pgx.ErrNoRows.
+func (q *Queries) DismissAlert(ctx context.Context, id, userID uuid.UUID) (Alert, error) {
+	var a Alert
+	err := q.pool.QueryRow(ctx, `
+		UPDATE alerts
+		SET dismissed_at = now(), dismissed_by = $2, updated_at = now()
+		WHERE id = $1 AND dismissed_at IS NULL
+		RETURNING id, organization_id, facility_id, type, severity, subject_type, subject_id,
+		          message, details, created_at, updated_at, dismissed_at, dismissed_by`,
+		id, userID,
+	).Scan(
+		&a.ID, &a.OrganizationID, &a.FacilityID, &a.Type, &a.Severity, &a.SubjectType, &a.SubjectID,
+		&a.Message, &a.Details, &a.CreatedAt, &a.UpdatedAt, &a.DismissedAt, &a.DismissedBy,
+	)
+	return a, err
 }

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -32,4 +32,12 @@ type Store interface {
 	ListInstrumentStatuses(ctx context.Context, facilityID uuid.UUID) ([]InstrumentStatus, error)
 	GetOrganizationIDForResult(ctx context.Context, resultID uuid.UUID) (uuid.UUID, error)
 	ListAuditLog(ctx context.Context, recordID uuid.UUID) ([]AuditEntry, error)
+
+	// Alerts
+	ListAllFacilities(ctx context.Context) ([]Facility, error)
+	ListFacilityExceedances(ctx context.Context, facilityID uuid.UUID) ([]Exceedance, error)
+	CreateAlert(ctx context.Context, p CreateAlertParams) (Alert, bool, error)
+	ListAlerts(ctx context.Context, f AlertFilter) ([]Alert, error)
+	GetAlert(ctx context.Context, id uuid.UUID) (Alert, error)
+	DismissAlert(ctx context.Context, id, userID uuid.UUID) (Alert, error)
 }

--- a/migrations/003_alerts.down.sql
+++ b/migrations/003_alerts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS alerts;

--- a/migrations/003_alerts.up.sql
+++ b/migrations/003_alerts.up.sql
@@ -1,0 +1,35 @@
+-- 003_alerts.up.sql
+-- Alerts for compliance exceedances and overdue instrument calibrations.
+--
+-- A background evaluator creates alerts by scanning sample_results (against
+-- effective permit_limits) and instruments (against due_at). The partial
+-- unique index deduplicates: an active alert for the same subject cannot
+-- be created twice. When dismissed, a new alert can be raised again.
+
+CREATE TABLE alerts (
+    id              UUID PRIMARY KEY,
+    organization_id UUID NOT NULL REFERENCES organizations(id),
+    facility_id     UUID NOT NULL REFERENCES facilities(id),
+    type            TEXT NOT NULL CHECK (type IN ('exceedance', 'overdue_calibration')),
+    severity        TEXT NOT NULL CHECK (severity IN ('info', 'warning', 'critical')),
+    subject_type    TEXT NOT NULL CHECK (subject_type IN ('sample_result', 'instrument')),
+    subject_id      UUID NOT NULL,
+    message         TEXT NOT NULL,
+    details         JSONB,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    dismissed_at    TIMESTAMPTZ,
+    dismissed_by    UUID REFERENCES users(id)
+);
+
+-- Dedupe: at most one active (not dismissed) alert per (facility, type, subject).
+CREATE UNIQUE INDEX alerts_active_subject_idx
+    ON alerts (facility_id, type, subject_type, subject_id)
+    WHERE dismissed_at IS NULL;
+
+CREATE INDEX idx_alerts_facility_active
+    ON alerts (facility_id, created_at DESC)
+    WHERE dismissed_at IS NULL;
+
+CREATE INDEX idx_alerts_org            ON alerts (organization_id);
+CREATE INDEX idx_alerts_type           ON alerts (type, created_at DESC);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,25 +1,38 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getUser, clearAuth, primaryRole, type AuthUser } from "./api/auth";
+import { api } from "./api/client";
 import { LoginPage } from "./components/LoginPage";
 import { FacilitySelector } from "./components/FacilitySelector";
 import { SampleResultsTable } from "./components/SampleResultsTable";
 import { ComplianceView } from "./components/ComplianceView";
 import { TrendingCharts } from "./components/TrendingCharts";
 import { InstrumentsView } from "./components/InstrumentsView";
+import { AlertsView } from "./components/AlertsView";
 
-type Tab = "results" | "trending" | "compliance" | "instruments";
+type Tab = "results" | "trending" | "compliance" | "instruments" | "alerts";
 
 const TABS: { key: Tab; label: string }[] = [
   { key: "results", label: "Sample Results" },
   { key: "trending", label: "Trending" },
   { key: "compliance", label: "Compliance" },
   { key: "instruments", label: "Instruments" },
+  { key: "alerts", label: "Alerts" },
 ];
 
 function App() {
   const [user, setUser] = useState<AuthUser | null>(getUser);
   const [facilityId, setFacilityId] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("results");
+
+  const { data: activeAlerts } = useQuery({
+    queryKey: ["alerts", { facility_id: facilityId ?? "", dismissed: false }],
+    queryFn: () =>
+      api.listAlerts({ facility_id: facilityId ?? undefined, dismissed: false }),
+    enabled: !!user && !!facilityId,
+    refetchInterval: 60_000,
+  });
+  const alertCount = activeAlerts?.length ?? 0;
 
   if (!user) {
     return <LoginPage onLogin={() => setUser(getUser())} />;
@@ -81,13 +94,18 @@ function App() {
                 <button
                   key={t.key}
                   onClick={() => setTab(t.key)}
-                  className={`px-4 py-2 text-sm font-medium ${
+                  className={`flex items-center gap-2 px-4 py-2 text-sm font-medium ${
                     tab === t.key
                       ? "border-b-2 border-blue-500 text-blue-600"
                       : "text-gray-500 hover:text-gray-700"
                   }`}
                 >
                   {t.label}
+                  {t.key === "alerts" && alertCount > 0 && (
+                    <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+                      {alertCount}
+                    </span>
+                  )}
                 </button>
               ))}
             </div>
@@ -103,6 +121,9 @@ function App() {
             )}
             {tab === "instruments" && (
               <InstrumentsView facilityId={facilityId} />
+            )}
+            {tab === "alerts" && (
+              <AlertsView facilityId={facilityId} user={user} />
             )}
           </>
         )}

--- a/web/src/api/auth.test.ts
+++ b/web/src/api/auth.test.ts
@@ -4,6 +4,7 @@ import {
   hasAnyRole,
   canReview,
   canApprove,
+  canDismissAlert,
   primaryRole,
   getToken,
   getUser,
@@ -105,6 +106,28 @@ describe("canApprove", () => {
   });
   it("returns false for operator", () => {
     expect(canApprove(makeUser([{ role: "operator" }]))).toBe(false);
+  });
+});
+
+// =========================================================================
+// canDismissAlert
+// =========================================================================
+
+describe("canDismissAlert", () => {
+  it("returns true for admin", () => {
+    expect(canDismissAlert(makeUser([{ role: "admin" }]))).toBe(true);
+  });
+  it("returns true for operator", () => {
+    expect(canDismissAlert(makeUser([{ role: "operator" }]))).toBe(true);
+  });
+  it("returns true for reviewer", () => {
+    expect(canDismissAlert(makeUser([{ role: "reviewer" }]))).toBe(true);
+  });
+  it("returns false for viewer", () => {
+    expect(canDismissAlert(makeUser([{ role: "viewer" }]))).toBe(false);
+  });
+  it("returns false for no roles", () => {
+    expect(canDismissAlert(makeUser([]))).toBe(false);
   });
 });
 

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -30,6 +30,10 @@ export function canApprove(user: AuthUser): boolean {
   return hasRole(user, "admin");
 }
 
+export function canDismissAlert(user: AuthUser): boolean {
+  return hasAnyRole(user, ["admin", "operator", "reviewer"]);
+}
+
 export function primaryRole(user: AuthUser): string {
   const order = ["admin", "reviewer", "operator", "viewer"];
   for (const role of order) {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -237,3 +237,70 @@ describe("api.approveSampleResult", () => {
     expect(init.method).toBe("PATCH");
   });
 });
+
+// =========================================================================
+// Alerts
+// =========================================================================
+
+describe("api.listAlerts", () => {
+  it("requests /alerts with no query when filter is empty", async () => {
+    mockFetch([]);
+    await api.listAlerts();
+    expect(lastFetchCall()[0]).toBe("/api/v1/alerts");
+  });
+
+  it("includes facility_id filter in query", async () => {
+    mockFetch([]);
+    await api.listAlerts({ facility_id: "fac-1" });
+    const url = lastFetchCall()[0];
+    expect(url).toContain("/api/v1/alerts?");
+    expect(url).toContain("facility_id=fac-1");
+  });
+
+  it("serializes type, dismissed, and limit", async () => {
+    mockFetch([]);
+    await api.listAlerts({ type: "exceedance", dismissed: false, limit: 25 });
+    const url = lastFetchCall()[0];
+    expect(url).toContain("type=exceedance");
+    expect(url).toContain("dismissed=false");
+    expect(url).toContain("limit=25");
+  });
+
+  it("includes dismissed=true explicitly", async () => {
+    mockFetch([]);
+    await api.listAlerts({ dismissed: true });
+    expect(lastFetchCall()[0]).toContain("dismissed=true");
+  });
+
+  it("sends GET with auth header when token present", async () => {
+    store["wqm_token"] = "tok-1";
+    mockFetch([]);
+    await api.listAlerts({ facility_id: "fac-1" });
+    const [, init] = lastFetchCall();
+    expect(init.method).toBeUndefined();
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer tok-1");
+  });
+});
+
+describe("api.dismissAlert", () => {
+  it("sends POST to correct URL", async () => {
+    mockFetch({ id: "a-1", dismissed_at: "2026-04-20T00:00:00Z" });
+    await api.dismissAlert("a-1");
+    const [url, init] = lastFetchCall();
+    expect(url).toBe("/api/v1/alerts/a-1/dismiss");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+  });
+
+  it("throws error from body on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: () => Promise.resolve({ error: "already dismissed" }),
+      })
+    );
+    await expect(api.dismissAlert("a-1")).rejects.toThrow("already dismissed");
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -11,6 +11,8 @@ import type {
   InstrumentStatus,
   CalibrationRecord,
   AuditEntry,
+  Alert,
+  AlertFilter,
 } from "./types";
 
 import { getToken, clearAuth } from "./auth";
@@ -120,5 +122,19 @@ export const api = {
 
   approveSampleResult(id: string) {
     return patch<SampleResult>(`/sample-results/${id}/approve`, {});
+  },
+
+  listAlerts(filter: AlertFilter = {}) {
+    const params: Record<string, string> = {};
+    if (filter.facility_id) params.facility_id = filter.facility_id;
+    if (filter.type) params.type = filter.type;
+    if (filter.dismissed !== undefined) params.dismissed = String(filter.dismissed);
+    if (filter.limit) params.limit = String(filter.limit);
+    const query = new URLSearchParams(params).toString();
+    return get<Alert[]>(`/alerts${query ? `?${query}` : ""}`);
+  },
+
+  dismissAlert(id: string) {
+    return post<Alert>(`/alerts/${id}/dismiss`, {});
   },
 };

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -172,3 +172,30 @@ export interface AuditEntry {
   changed_at: string;
   reason?: string;
 }
+
+export type AlertType = "exceedance" | "overdue_calibration";
+export type AlertSeverity = "info" | "warning" | "critical";
+export type AlertSubjectType = "sample_result" | "instrument";
+
+export interface Alert {
+  id: string;
+  organization_id: string;
+  facility_id: string;
+  type: AlertType;
+  severity: AlertSeverity;
+  subject_type: AlertSubjectType;
+  subject_id: string;
+  message: string;
+  details?: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+  dismissed_at?: string;
+  dismissed_by?: string;
+}
+
+export interface AlertFilter {
+  facility_id?: string;
+  type?: AlertType;
+  dismissed?: boolean;
+  limit?: number;
+}

--- a/web/src/components/AlertsView.tsx
+++ b/web/src/components/AlertsView.tsx
@@ -1,0 +1,197 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { api } from "../api/client";
+import { canDismissAlert, type AuthUser } from "../api/auth";
+import type { Alert, AlertSeverity, AlertType } from "../api/types";
+
+const SEVERITY_STYLES: Record<AlertSeverity, { bg: string; text: string; label: string }> = {
+  critical: { bg: "bg-red-100", text: "text-red-800", label: "Critical" },
+  warning: { bg: "bg-yellow-100", text: "text-yellow-800", label: "Warning" },
+  info: { bg: "bg-blue-100", text: "text-blue-800", label: "Info" },
+};
+
+const TYPE_LABELS: Record<AlertType, string> = {
+  exceedance: "Exceedance",
+  overdue_calibration: "Overdue Calibration",
+};
+
+function SeverityBadge({ severity }: { severity: AlertSeverity }) {
+  const s = SEVERITY_STYLES[severity];
+  return (
+    <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${s.bg} ${s.text}`}>
+      {s.label}
+    </span>
+  );
+}
+
+interface Props {
+  facilityId: string;
+  user: AuthUser;
+}
+
+export function AlertsView({ facilityId, user }: Props) {
+  const queryClient = useQueryClient();
+  const [typeFilter, setTypeFilter] = useState<AlertType | "">("");
+  const [showDismissed, setShowDismissed] = useState(false);
+
+  const filter = {
+    facility_id: facilityId,
+    ...(typeFilter ? { type: typeFilter } : {}),
+    dismissed: showDismissed,
+  };
+
+  const { data: alerts, isLoading } = useQuery({
+    queryKey: ["alerts", filter],
+    queryFn: () => api.listAlerts(filter),
+  });
+
+  const dismissMutation = useMutation({
+    mutationFn: (id: string) => api.dismissAlert(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["alerts"] }),
+  });
+
+  const canDismiss = canDismissAlert(user);
+
+  if (isLoading) {
+    return <div className="py-8 text-center text-sm text-gray-500">Loading...</div>;
+  }
+
+  const criticalCount = alerts?.filter((a) => a.severity === "critical" && !a.dismissed_at).length ?? 0;
+  const warningCount = alerts?.filter((a) => a.severity === "warning" && !a.dismissed_at).length ?? 0;
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Alerts</h2>
+        <div className="flex gap-3 text-sm">
+          {criticalCount > 0 && (
+            <span className="font-medium text-red-600">{criticalCount} critical</span>
+          )}
+          {warningCount > 0 && (
+            <span className="font-medium text-yellow-600">{warningCount} warning</span>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-4 flex flex-wrap gap-3 text-sm">
+        <label className="flex items-center gap-2">
+          <span className="text-gray-600">Type:</span>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value as AlertType | "")}
+            className="rounded border border-gray-300 px-2 py-1 text-sm"
+          >
+            <option value="">All</option>
+            <option value="exceedance">Exceedance</option>
+            <option value="overdue_calibration">Overdue Calibration</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={showDismissed}
+            onChange={(e) => setShowDismissed(e.target.checked)}
+          />
+          <span className="text-gray-600">Include dismissed</span>
+        </label>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-gray-200">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Severity
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Type
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Message
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Created
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500">
+                Status
+              </th>
+              <th className="px-4 py-2 text-center text-xs font-medium uppercase text-gray-500">
+                Action
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {alerts?.map((alert) => (
+              <AlertRow
+                key={alert.id}
+                alert={alert}
+                canDismiss={canDismiss}
+                onDismiss={() => dismissMutation.mutate(alert.id)}
+                pending={dismissMutation.isPending && dismissMutation.variables === alert.id}
+              />
+            ))}
+            {alerts?.length === 0 && (
+              <tr>
+                <td colSpan={6} className="py-8 text-center text-sm text-gray-400">
+                  No alerts
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function AlertRow({
+  alert,
+  canDismiss,
+  onDismiss,
+  pending,
+}: {
+  alert: Alert;
+  canDismiss: boolean;
+  onDismiss: () => void;
+  pending: boolean;
+}) {
+  const isDismissed = !!alert.dismissed_at;
+  const rowBg = isDismissed
+    ? "bg-gray-50 opacity-60"
+    : alert.severity === "critical"
+    ? "bg-red-50"
+    : "";
+
+  return (
+    <tr className={`hover:bg-gray-100 ${rowBg}`}>
+      <td className="px-4 py-2">
+        <SeverityBadge severity={alert.severity} />
+      </td>
+      <td className="px-4 py-2 text-sm text-gray-600">{TYPE_LABELS[alert.type]}</td>
+      <td className="px-4 py-2 text-sm text-gray-900">{alert.message}</td>
+      <td className="px-4 py-2 text-sm text-gray-500">
+        {new Date(alert.created_at).toLocaleString()}
+      </td>
+      <td className="px-4 py-2 text-sm">
+        {isDismissed ? (
+          <span className="text-gray-500">
+            Dismissed {new Date(alert.dismissed_at!).toLocaleDateString()}
+          </span>
+        ) : (
+          <span className="font-medium text-gray-700">Active</span>
+        )}
+      </td>
+      <td className="px-4 py-2 text-center">
+        {!isDismissed && canDismiss && (
+          <button
+            onClick={onDismiss}
+            disabled={pending}
+            className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+          >
+            {pending ? "Dismissing..." : "Dismiss"}
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a background evaluator that scans all facilities on an interval (default 5m, configurable via `ALERT_EVAL_INTERVAL`), generating alerts for permit-limit exceedances and overdue instrument calibrations. Dedupe is enforced via a partial unique index on active rows, and every insert is published to NATS so the existing audit consumer records it.
- Exposes `GET /api/v1/alerts` (filter by `facility_id`, `type`, `dismissed`, `limit`) and `POST /api/v1/alerts/{id}/dismiss` (admin/operator/reviewer). Facility-scoped users only see alerts they can access.
- Frontend adds an **Alerts** tab with severity-colored rows, type + dismissed filters, and a dismiss button gated to admin/operator/reviewer. The tab label shows an active-alert count badge that refreshes every 60s.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — new `internal/alerts` and `internal/api/alerts_test.go` suites pass
- [x] `cd web && npx tsc --noEmit`
- [x] `cd web && npm test` — 59 tests pass including new `canDismissAlert`, `listAlerts`, and `dismissAlert` cases
- [x] Manual smoke: bring up stack, seed, verify exceedance alert appears within one tick and dedupes on re-run
- [x] Manual smoke: confirm dismiss button disappears for viewer role and works for operator/reviewer/admin

Closes #16